### PR TITLE
opx-nas-linux sync - 3.0.0-dev2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-linux], [5.19.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-linux], [5.22.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+opx-nas-linux (5.22.0) unstable; urgency=medium
+
+  * Bugfix: Non-default VRF with MASQURADE option should not change the source IP of the forwarded traffic.
+  * Bugfix: Kernel is not updated with the CoPP ACL destination address correctly. 
+  * Update: Cleanup vrf-firewall outgoing service model that handles service binding config.
+            Ensuring proper handling of private ip/port allocation/de-allocation.
+  * Update: Support for dst_ip filter type for COPP ACL
+  * Bugfix: Added rule to drop all flooded queries except the general queries.
+  * Bugfix: Support for oper. status publish thru BASE_IF_LINUX_IF_INTERFACES_INTERFACE_IF_FLAGS 
+            CPS attribute from NAS-linux.
+  * Update: Added support for CPS Get query on IP address, based on non-default VRF name filter. 
+  * Update: Added support to handle snoop routes with no OIF(out going interfaces).
+  * Update: Added support for outgoing source address translation as part of ns-outgoing-service model. 
+  * Update: Added UT scripts for outgoing service configuration.
+  * Update: Added interface attribute to incoming service model to support rule configuration on a specific port.
+  * Update: Added broadcast address during IP address configuration.
+  * Update: Added support for L4 destination port range for CoPP ACL.
+  * Update: Added default accept rule for lo interface to default netns.
+  * Bugfux: Fix ping failure after unconfigure and re-configure.
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 9 Jul 2018 19:25:43 -0800
+
 opx-nas-linux (5.19.0) unstable; urgency=medium
 
   * Feature: Support for VTY ACL squash

--- a/scripts/bin/base_vrf.py
+++ b/scripts/bin/base_vrf.py
@@ -24,13 +24,21 @@ import systemd.daemon
 import os
 from shutil import rmtree
 from dn_base_vrf_tool import log_err, log_info, process_pkt_reject_rule
-from dn_base_vrf_svcs_config import VrfIncomingSvcsRule,\
+from dn_base_vrf_svcs_config import VrfSvcsRuleType,\
+                                    VrfSvcsRuleAction,\
+                                    VrfSvcsRuleProto,\
                                     process_vrf_svcs_rule_add,\
                                     process_vrf_svcs_rule_set,\
                                     process_vrf_svcs_rule_del,\
                                     process_vrf_svcs_rule_del_by_id,\
                                     process_vrf_svcs_rule_get, \
-                                    process_vrf_svcs_clear_rules
+                                    process_vrf_svcs_clear_rules, \
+                                    process_vrf_outgoing_svcs_rule_add,\
+                                    process_vrf_outgoing_svcs_rule_del,\
+                                    process_vrf_outgoing_svcs_rule_del_by_id,\
+                                    process_vrf_outgoing_svcs_rule_get, \
+                                    process_vrf_outgoing_svcs_clear_rules
+
 _vrf_key = cps.key_from_name('target', 'vrf-mgmt/ni/network-instances/network-instance')
 _vrf_intf_key = cps.key_from_name('target', 'vrf-mgmt/ni/if/interfaces/interface')
 _vrf_incoming_svc_config_key = cps.key_from_name('target', 'vrf-firewall/ns-incoming-service')
@@ -45,6 +53,8 @@ _action = {
     1: 'ACCEPT',
     2: 'DROP',
     3: 'DNAT',
+    4: 'REJECT',
+    5: 'SNAT',
 }
 _af = {
     2 : 'ipv4',
@@ -69,24 +79,30 @@ def vrf_mgmt_ni_attr(t):
 def ip_ni_attr(t):
     return 'ni/network-instances/network-instance/' + t
 
-def create_vrf_default_rules(vrf_name, vrf_id, rule_id_list = None):
+def create_vrf_default_rules(vrf_name, vrf_id = None, rule_id_list = None):
     for af in [socket.AF_INET, socket.AF_INET6]:
         any_ip_str = '0.0.0.0' if af == socket.AF_INET else '::'
-        intf_list = ['lo']
+        intf_list = []
         if vrf_name == 'default':
-            intf_list.append('vdef-nsid%s' % str(vrf_id))
+            if vrf_id is None:
+                intf_list.append('lo')
+            else:
+                intf_list.append('vdef-nsid%s' % str(vrf_id))
         else:
+            if vrf_id is None:
+                return False
+            intf_list.append('lo')
             intf_list.append('veth-nsid%s' % str(vrf_id))
         for intf in intf_list:
-            rule_id = process_vrf_svcs_rule_add(VrfIncomingSvcsRule.RULE_TYPE_ACL, vrf_name,
-                                                VrfIncomingSvcsRule.RULE_ACTION_ALLOW, af,
+            rule_id = process_vrf_svcs_rule_add(VrfSvcsRuleType.RULE_TYPE_ACL, vrf_name,
+                                                VrfSvcsRuleAction.RULE_ACTION_ALLOW, af,
                                                 src_ip = socket.inet_pton(af, any_ip_str), prefix_len = 0,
                                                 high_prio = True, in_intf = intf)
             if rule_id is None:
                 log_err('Failed to create default ACL rules: VRF %s af %d intf %s' % (vrf_name, af, intf))
                 return False
             if rule_id_list is not None:
-                log_info('Deault rule created: VRF %s af %d intf %s ID %d' % (vrf_name, af, intf, rule_id))
+                log_info('Default rule created: VRF %s af %d intf %s ID %d' % (vrf_name, af, intf, rule_id))
                 rule_id_list.append(rule_id)
     return True
 
@@ -236,9 +252,12 @@ def config_incoming_ip_svcs_int(methods, params):
     vrf_name = get_svcs_attr_val('ni-name')
     protocol = get_svcs_attr_val('protocol')
     dst_port = get_svcs_attr_val('dst-port')
+    low_dst_port = get_svcs_attr_val('lower-dst-port')
+    high_dst_port = get_svcs_attr_val('upper-dst-port')
     action = get_svcs_attr_val('action')
     src_ip = get_svcs_attr_val('src-ip')
     prefix_len = get_svcs_attr_val('src-prefix-len')
+    in_intf = get_svcs_attr_val('ifname')
     if operation == 'create':
         # set default seq number to 0 for create
         seq_num = get_svcs_attr_val('seq-num', 0)
@@ -268,10 +287,23 @@ def config_incoming_ip_svcs_int(methods, params):
                 prefix_len = 128
             in_param_list['src-prefix-len'] = prefix_len
 
+    # check lower & upper destination ports
+    if low_dst_port is not None and high_dst_port is None:
+        log_err('Missing upper-dst-port for VTY ACL rule configuration')
+        return False
+    if low_dst_port is None and high_dst_port is not None:
+        log_err('Missing lower-dst-port for VTY ACL rule configuration')
+        return False
+    if (low_dst_port is not None or high_dst_port is not None) and dst_port is not None:
+        log_err('Invalid VTY ACL rule configuration, \
+                 dst port attribute cannot be configured along with dst port range attributes')
+        return False
+
     """
     The input object stands for VTY ACL configuration request if:
-    1. Destination L4 port attribute is not given or given value is 0.
-    2. Or Source IP address attribute is given
+    1. Destination L4 port attribute is not given or given value is 0,
+    2. Or Source IP address attribute is given,
+    3. Or lower & upper destination L4 port attributes are given.
 
     For all other cases, input object stands for VRF incoming IP service
     request.
@@ -280,6 +312,8 @@ def config_incoming_ip_svcs_int(methods, params):
         if dst_port is None or dst_port == 0:
             return True
         if src_ip is not None:
+            return True
+        if low_dst_port is not None and high_dst_port is not None:
             return True
         return False
 
@@ -311,11 +345,11 @@ def config_incoming_ip_svcs_int(methods, params):
 
     if is_vty_acl_config():
         log_info('Handle VTY ACL configuration, operation: %s' % operation)
-        rule_type = VrfIncomingSvcsRule.RULE_TYPE_ACL
+        rule_type = VrfSvcsRuleType.RULE_TYPE_ACL
         reqd_input = ['ni-name', 'af', 'src-ip', 'src-prefix-len', 'action']
     else:
         log_info('Handle incoming IP configuration, operation: %s' % operation)
-        rule_type = VrfIncomingSvcsRule.RULE_TYPE_IP
+        rule_type = VrfSvcsRuleType.RULE_TYPE_IP
         reqd_input = ['af', 'ni-name', 'protocol', 'dst-port']
         if vrf_name == 'default':
             reqd_input.append('action')
@@ -360,30 +394,38 @@ def config_incoming_ip_svcs_int(methods, params):
         return False
 
     if operation == 'create':
-        if rule_type == VrfIncomingSvcsRule.RULE_TYPE_IP and vrf_name != 'default':
+        if rule_type == VrfSvcsRuleType.RULE_TYPE_IP and vrf_name != 'default':
             """
             If it is IP forwarding rule and the name space is not default, we set its action
             type as DNAT
             """
             dst_ip = dn_base_vrf_tool.get_veth_ip(af, vrf_name)
-            action = VrfIncomingSvcsRule.RULE_ACTION_DNAT
+            action = VrfSvcsRuleAction.RULE_ACTION_DNAT
         else:
             if (dst_port is not None and
-                protocol != VrfIncomingSvcsRule.RULE_PROTO_TCP and
-                protocol != VrfIncomingSvcsRule.RULE_PROTO_UDP):
+                protocol != VrfSvcsRuleProto.RULE_PROTO_TCP and
+                protocol != VrfSvcsRuleProto.RULE_PROTO_UDP):
                 log_err('L4 destination port filter must with protocol type TCP or UDP')
+                return False
+            if (low_dst_port is not None and
+                protocol != VrfSvcsRuleProto.RULE_PROTO_TCP and
+                protocol != VrfSvcsRuleProto.RULE_PROTO_UDP):
+                log_err('L4 destination port range filter must with protocol type TCP or UDP')
                 return False
             dst_ip = None
         ret_val = process_vrf_svcs_rule_add(rule_type, vrf_name, action, af,
                                             src_ip = src_ip, prefix_len = prefix_len, dst_ip = dst_ip,
                                             seq_num = seq_num, protocol = protocol, dst_port = dst_port,
-                                            rule_id = rule_id)
+                                            low_dst_port = low_dst_port, high_dst_port = high_dst_port,
+                                            in_intf = in_intf, rule_id = rule_id)
         if ret_val is None:
-            log_err('Failed to add incoming IP rule: VRF %s AF %s%s%s%s%s%s%s%s' % (
+            log_err('Failed to add incoming IP rule: VRF %s AF %s%s%s%s%s%s%s%s%s%s' % (
                         vrf_name, _af[af],
+                        (' IIF %s' % in_intf if in_intf is not None else ' '),
                         (' SRC %s/%d' % (get_ip_str(src_ip), prefix_len) if src_ip is not None and prefix_len is not None else ''),
                         (' PROTO %s' % _protocol[protocol] if protocol is not None else ''),
                         (' PORT %d' % dst_port if dst_port is not None else ''),
+                        (' PORT RANGE %d-%d' % (low_dst_port, high_dst_port) if low_dst_port is not None else ''),
                         (' SEQ %d' % seq_num if seq_num is not None else ''),
                         (' ACTION %s' % _action[action] if action is not None else ''),
                         (' DST %s' % get_ip_str(dst_ip) if dst_ip is not None else ''),
@@ -397,24 +439,27 @@ def config_incoming_ip_svcs_int(methods, params):
         ret_val = process_vrf_svcs_rule_set(rule_id, src_ip = src_ip,
                                             prefix_len = prefix_len, protocol = protocol,
                                             dst_port = dst_port, action = action,
-                                            seq_num = seq_num)
+                                            low_dst_port = low_dst_port, high_dst_port = high_dst_port,
+                                            seq_num = seq_num, in_intf = in_intf)
         if not ret_val:
             log_err('Failed to update rule with ID %d' % rule_id)
             return False
     elif operation == 'delete':
         if rule_id is None:
-            if rule_type == VrfIncomingSvcsRule.RULE_TYPE_IP and vrf_name != 'default':
+            if rule_type == VrfSvcsRuleType.RULE_TYPE_IP and vrf_name != 'default':
                 """
                 If it is IP forwarding rule and the name space is not default, we set its action
                 type as DNAT
                 """
                 dst_ip = dn_base_vrf_tool.get_veth_ip(af, vrf_name)
-                action = VrfIncomingSvcsRule.RULE_ACTION_DNAT
+                action = VrfSvcsRuleAction.RULE_ACTION_DNAT
             else:
                 dst_ip = None
             ret_val = process_vrf_svcs_rule_del(rule_type, vrf_name, action, af,
                                                 src_ip = src_ip, prefix_len = prefix_len, dst_ip = dst_ip,
-                                                protocol = protocol, dst_port = dst_port)
+                                                protocol = protocol, dst_port = dst_port,
+                                                low_dst_port = low_dst_port, high_dst_port = high_dst_port,
+                                                in_intf = in_intf)
         else:
             ret_val = process_vrf_svcs_rule_del_by_id(rule_id)
         if not ret_val:
@@ -433,81 +478,273 @@ def config_incoming_ip_svcs_cb(methods, params):
         logging.exception(ex)
         return False
 
-def _create_ip_from_attr(addr, iptype):
-    addr = binascii.unhexlify(addr)
-    af = socket.AF_INET
-    if _af[iptype] == 'ipv6':
-        af = socket.AF_INET6
-    addr = socket.inet_ntop(af, addr)
-    return addr
-
-def config_outgoing_ip_svcs_cb(methods, params):
+def config_outgoing_ip_svcs_int(methods, params):
     obj = cps_object.CPSObject(obj=params['change'])
+    in_param_list = {}
 
-    vrf_name = outgoing_ip_svcs_attr('ni-name')
-    af = outgoing_ip_svcs_attr('af')
-    public_ip = outgoing_ip_svcs_attr('public-ip')
-    protocol = outgoing_ip_svcs_attr('protocol')
-    public_port = outgoing_ip_svcs_attr('public-port')
-    try:
-        af = obj.get_attr_data(af)
-        vrf_name = obj.get_attr_data(vrf_name)
-        public_ip_data = obj.get_attr_data(public_ip)
-        public_ip = _create_ip_from_attr(public_ip_data,af)
-        protocol = obj.get_attr_data(protocol)
-        public_port = obj.get_attr_data(public_port)
-
-    except ValueError as e:
-        log_msg = 'Missing mandatory attribute ' + e.args[0]
-        log_err(log_msg)
-        return False
+    log_info('Callback for outgoing IP service configuration')
+    def get_svcs_attr_val(attr_name, dft_val = None):
+        attr_id = outgoing_ip_svcs_attr(attr_name)
+        try:
+            attr_val = obj.get_attr_data(attr_id)
+        except ValueError:
+            attr_val = None
+        if attr_val is None:
+            attr_val = dft_val
+        in_param_list[attr_name] = attr_val
+        return attr_val
 
     operation = params['operation']
 
-    log_msg = 'Operation:' + operation + ' VRF:' + vrf_name + ' family:'\
-              + _af[af] + ' public-ip' + public_ip + ' protocol:' + _protocol[protocol] + ' public-port:'\
-              + str(public_port)
-    log_info(log_msg)
+    vrf_name = get_svcs_attr_val('ni-name')
+    af = get_svcs_attr_val('af')
+    public_ip_attr = get_svcs_attr_val('public-ip')
+    outgoing_source_ip_attr = get_svcs_attr_val('outgoing-source-ip')
+    protocol = get_svcs_attr_val('protocol')
+    public_port = get_svcs_attr_val('public-port')
+    private_ip_attr = get_svcs_attr_val('private-ip')
+    private_port = get_svcs_attr_val('private-port')
+
+    rule_id = get_svcs_attr_val('id')
+
+    orig_af = af
+    public_ip = None
+    # check public IP
+    if public_ip_attr is not None:
+        af_ip = check_ip_validity(orig_af, public_ip_attr)
+        if af_ip is None:
+            log_err('Invalid public IP %s for rule configuration' % public_ip_attr)
+            return False
+        af, public_ip = af_ip
+        if orig_af is None:
+            log_info('Address family %d is deducted from input public IP %s' %
+                     (af, public_ip_attr))
+            in_param_list['af'] = af
+        in_param_list['public-ip'] = public_ip
+
+    outgoing_source_ip = None
+    # check outgoing source IP
+    if outgoing_source_ip_attr is not None:
+        af_ip = check_ip_validity(orig_af, outgoing_source_ip_attr)
+        if af_ip is None:
+            log_err('Invalid outgoing source IP %s for rule configuration' % outgoing_source_ip_attr)
+            return False
+        af, outgoing_source_ip = af_ip
+        if orig_af is None:
+            log_info('Address family %d is deducted from input source IP %s' %
+                     (af, outgoing_source_ip_attr))
+            in_param_list['af'] = af
+        in_param_list['outgoing-source-ip'] = outgoing_source_ip
+
+    private_ip = None
+    # check private IP
+    if private_ip_attr is not None:
+        af_ip = check_ip_validity(orig_af, private_ip_attr)
+        if af_ip is None:
+            log_err('Invalid private IP %s for rule configuration' % private_ip_attr)
+            return False
+        af, private_ip = af_ip
+        if orig_af is None:
+            log_info('Address family %d is deducted from input private IP %s' %
+                     (af, private_ip_attr))
+            in_param_list['af'] = af
+        in_param_list['private-ip'] = private_ip
+
+    """
+    The input object stands for Source IP configuration request if:
+    1. Outgoing source IP attribute is given
+
+    For all other cases, input object stands for VRF outgoing IP service
+    binding request.
+    """
+    def is_egress_source_ip_config():
+        if outgoing_source_ip is not None:
+            return True
+        return False
+
+    def check_attr_list(attr_list, missed_list = None):
+        ret_val = True
+        for attr in attr_list:
+            if attr not in in_param_list or in_param_list[attr] is None:
+                ret_val = False
+                if missed_list is not None:
+                    missed_list.append(attr)
+        return ret_val
+
+    def get_ip_str(ip_bin):
+        for af in [socket.AF_INET, socket.AF_INET6]:
+            try:
+                ip_str = socket.inet_ntop(af, ip_bin)
+                return ip_str
+            except TypeError:
+                continue
+        return '-'
+
+    log_info('Input parameters:')
+    for name, val in in_param_list.items():
+        if val is not None:
+            if name == 'public-ip' or name == 'outgoing-source-ip' or name == 'private-ip':
+                log_info('  %-10s - %s' % (name, binascii.hexlify(val)))
+            else:
+                log_info('  %-10s - %s' % (name, str(val)))
+
+    if is_egress_source_ip_config():
+        log_info('Handle Outgoing Source IP configuration, operation: %s' % operation)
+        rule_type = VrfSvcsRuleType.RULE_TYPE_SNAT
+        action    = VrfSvcsRuleAction.RULE_ACTION_SNAT
+        reqd_input = ['ni-name', 'af', 'public-ip', 'protocol', 'public-port', 'outgoing-source-ip']
+    else:
+        log_info('Handle Outgoing IP service binding configuration, operation: %s' % operation)
+        rule_type = VrfSvcsRuleType.RULE_TYPE_OUT_IP
+        action    = VrfSvcsRuleAction.RULE_ACTION_DNAT
+        reqd_input = ['ni-name', 'af', 'public-ip', 'protocol', 'public-port']
+
+    def check_rule_input(missed_attr_list = None):
+        """ The keys to identify a rule """
+        if operation == 'delete':
+            """
+            For delete operation, either rule ID or rule keys need to be given to find
+            rule to be deleted
+            """
+            if rule_id is not None:
+                return True
+            else:
+                if check_attr_list(reqd_input, missed_attr_list):
+                    return True
+        elif operation == 'set':
+            """
+            set operation, not supported on outgoing IP service configuration
+            """
+            return False
+        elif operation == 'create':
+            """
+            For create operation, all key attributes need to be given
+            """
+            if check_attr_list(reqd_input, missed_attr_list):
+                return True
+        return False
+
+    not_found_list = []
+    if not check_rule_input(not_found_list):
+        log_err('Operation not support or Mandatory attributes %s not found for operation %s' %
+                (str(not_found_list), operation))
+        return False
+
+    log_info('Outgoing IP service rule: Operation %s VRF %s AF %s%s%s%s%s%s' % (
+              operation, vrf_name,
+              (_af[af] if af is not None else ' '),
+              (' public-ip %s' % (get_ip_str(public_ip)) if public_ip is not None else ''),
+              (' protocol %s' % _protocol[protocol] if protocol is not None else ''),
+              (' public-port %d' % public_port if public_port is not None else ''),
+              (' outgoing-source-ip %s' %
+                  (get_ip_str(outgoing_source_ip)) if outgoing_source_ip is not None else ''),
+              (' ID %d' % rule_id if rule_id is not None else '')))
     try:
         if operation == 'set':
             return False
         elif operation == 'create':
-            ret_val, private_port, private_ip = dn_base_vrf_tool.process_outgoing_ip_svcs_config(True,\
-                                    _af[af], public_ip, _protocol[protocol],\
-                                    str(public_port), vrf_name)
-            family = socket.AF_INET
-            if _af[af] == 'ipv6':
-                family = socket.AF_INET6
-            if ret_val is True:
-                private_ip = binascii.hexlify(socket.inet_pton(family, private_ip))
-                cps_obj = cps_object.CPSObject(module='vrf-firewall/ns-outgoing-service', qual='target',
-                                           data={outgoing_ip_svcs_attr('ni-name'):vrf_name,
-                                           outgoing_ip_svcs_attr('af'):af,
-                                           outgoing_ip_svcs_attr('public-ip'):public_ip_data,
-                                           outgoing_ip_svcs_attr('protocol'):protocol,
-                                           outgoing_ip_svcs_attr('public-port'):public_port,
-                                           outgoing_ip_svcs_attr('private-ip'):private_ip,
-                                           outgoing_ip_svcs_attr('private-port'):private_port
-                                           })
-                params['change'] = cps_obj.get()
+            ret = True
+            ret_val = None
+            if rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+                ret, private_ip, private_port = dn_base_vrf_tool.process_outgoing_ip_svcs_sub_net_config(True,\
+                                                     vrf_name, af, protocol, public_ip, public_port)
+            if ret is False:
+                log_err('Failed to retrieve private IP, port for outgoing service binding config.')
+            else:
+                ret_val = process_vrf_outgoing_svcs_rule_add(rule_type, vrf_name, action, af,
+                                                    dst_ip = public_ip, protocol = protocol,
+                                                    dst_port = public_port,
+                                                    out_src_ip = outgoing_source_ip,
+                                                    private_ip = private_ip,
+                                                    private_port = private_port,
+                                                    rule_id = rule_id)
+
+            log_info('%s in adding outgoing %s: VRF %s AF %s%s%s%s%s%s%s%s%s' % (
+                    ('Success' if ret_val is not None else 'Failure'),
+                    ('%s rule' % 'SNAT' if rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT else 'IP'),
+                    vrf_name,
+                    (_af[af] if af is not None else ' '),
+                    (' PROTO %s' % _protocol[protocol] if protocol is not None else ''),
+                    (' DST IP %s' % get_ip_str(public_ip) if public_ip is not None else ''),
+                    (' PORT %d' % public_port if public_port is not None else ''),
+                    (' ACTION %s' % _action[action] if action is not None else ''),
+                    (' SRC IP %s' %
+                        get_ip_str(outgoing_source_ip) if outgoing_source_ip is not None else ''),
+                    (' PRIVATE IP %s' % get_ip_str(private_ip) if private_ip is not None else ''),
+                    (' PRIVATE PORT %d' % private_port if private_port is not None else ''),
+                    (' ID %d' % ret_val if ret_val is not None else '')))
+
+            if ret_val is not None:
+                if rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+                    #SNAT flow
+                    obj.add_attr(outgoing_ip_svcs_attr('id'), ret_val)
+                    params['change'] = obj.get()
+                else:
+                    #DNAT - service binding flow
+                    private_ip = binascii.hexlify(private_ip)
+                    cps_obj = cps_object.CPSObject(module='vrf-firewall/ns-outgoing-service', qual='target',
+                                               data={
+                                               outgoing_ip_svcs_attr('id'):ret_val,
+                                               outgoing_ip_svcs_attr('ni-name'):vrf_name,
+                                               outgoing_ip_svcs_attr('af'):af,
+                                               outgoing_ip_svcs_attr('public-ip'):public_ip_attr,
+                                               outgoing_ip_svcs_attr('protocol'):protocol,
+                                               outgoing_ip_svcs_attr('public-port'):public_port,
+                                               outgoing_ip_svcs_attr('private-ip'):private_ip,
+                                               outgoing_ip_svcs_attr('private-port'):private_port
+                                               })
+                    params['change'] = cps_obj.get()
                 return True
         elif operation == 'delete':
-            ret_val, private_port, private_ip = dn_base_vrf_tool.process_outgoing_ip_svcs_config(False,\
-                                    _af[af], public_ip, _protocol[protocol],\
-                                    str(public_port), vrf_name)
+            if rule_id is None:
+                ret_val = process_vrf_outgoing_svcs_rule_del(rule_type, vrf_name, action, af,
+                                                    dst_ip = public_ip, protocol = protocol, dst_port = public_port,
+                                                    out_src_ip = outgoing_source_ip, private_ip = private_ip,
+                                                    private_port = private_port)
+            else:
+                ret_val = process_vrf_outgoing_svcs_rule_del_by_id(rule_id)
+
             if ret_val is True:
-                return True
+                ret = True
+                if rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+                    #@@TODO - check: for delete case with rule_id (w/o af,protocol, public_ip ...) how to release the private_port inside process_outgoing_ip_svcs_sub_net_config.
+                    ret, private_ip, private_port = dn_base_vrf_tool.process_outgoing_ip_svcs_sub_net_config(False,\
+                                                     vrf_name, af, protocol, public_ip, public_port)
+                if ret is False:
+                    log_err('Failed to release private IP, port for outgoing service binding config.'
+                            ' VRF %s AF %s%s%s%s%s%s' % (
+                            vrf_name,
+                            (_af[af] if af is not None else ' '),
+                            (' PROTO %s' % _protocol[protocol] if protocol is not None else ''),
+                            (' DST IP %s' % get_ip_str(public_ip) if public_ip is not None else ''),
+                            (' PORT %d' % public_port if public_port is not None else ''),
+                            (' ACTION %s' % _action[action] if action is not None else ''),
+                            (' ID %d' % ret_val if ret_val is not None else '')))
+                else:
+                    #deleted successfully
+                    return True
     except Exception as e:
-        log_msg = 'Faild to commit operation.' + e + params
+        log_msg = ('%s %s %s' %('Failed to commit operation.',e,params))
         log_err(log_msg)
         return False
 
-    log_msg = 'Operation:' + operation + ' VRF:' + vrf_name + ' family:'\
-              + _af[af] + ' public-ip' + public_ip + ' protocol:' + _protocol[protocol] + ' public-port:'\
-              + str(public_port)
-    log_err(log_msg)
+    log_err('Outgoing IP service rule: Operation %s Failed VRF %s AF %s%s%s%s%s%s' % (
+               operation, vrf_name,
+               (_af[af] if af is not None else ' '),
+               (' public-ip %s' % (get_ip_str(public_ip)) if public_ip is not None else ''),
+               (' protocol %s' % _protocol[protocol] if protocol is not None else ''),
+               (' public-port %d' % public_port if public_port is not None else ''),
+               (' outgoing-source-ip %s' %
+                  (get_ip_str(outgoing_source_ip)) if outgoing_source_ip is not None else ''),
+               (' ID %d' % rule_id if rule_id is not None else '')))
     return False
 
+def config_outgoing_ip_svcs_cb(methods, params):
+    try:
+        return config_outgoing_ip_svcs_int(methods, params)
+    except Exception as ex:
+        logging.exception(ex)
+        return False
 
 def sigterm_hdlr(signum, frame):
     global shutdown
@@ -522,8 +759,11 @@ def get_incoming_ip_svcs_int(methods, params):
         'src-prefix-len': 'prefix_len',
         'protocol': 'protocol',
         'dst-port': 'dst_port',
+        'lower-dst-port': 'low_dst_port',
+        'upper-dst-port': 'high_dst_port',
         'action': 'action',
         'seq-num': 'seq_num',
+        'ifname': 'in_intf',
         'id': 'rule_id'}
     obj = cps_object.CPSObject(obj = params['filter'])
     resp = params['list']
@@ -575,6 +815,82 @@ def get_incoming_ip_svcs_cb(methods, params):
         logging.exception(ex)
         return False
 
+def get_outgoing_ip_svcs_int(methods, params):
+    log_info('Callback for outgoing IP service reading')
+    obj_attr_map = {
+        'ni-name': 'vrf_name',
+        'af': 'af',
+        'public-ip': 'dst_ip',
+        'protocol': 'protocol',
+        'public-port': 'dst_port',
+        'private-ip': 'private_ip',
+        'private-port': 'private_port',
+        'outgoing-source-ip': 'out_src_ip',
+        'id': 'rule_id'}
+    obj = cps_object.CPSObject(obj = params['filter'])
+    resp = params['list']
+    args = {}
+    for key, val in obj_attr_map.items():
+        attr_name = outgoing_ip_svcs_attr(key)
+        try:
+            attr_val = obj.get_attr_data(attr_name)
+        except ValueError:
+            attr_val = None
+        if attr_val is not None:
+            args[val] = attr_val
+
+    # check af
+    if 'af' in args and args['af'] is not None:
+        af = args['af']
+        if af != socket.AF_INET and af != socket.AF_INET6:
+            log_err('Invalid address family number %d' % af)
+            return False
+
+    # check public IP
+    if 'dst_ip' in args and args['dst_ip'] is not None:
+        af = args['af'] if 'af' in args else None
+        af_ip = check_ip_validity(af, args['dst_ip'])
+        if af_ip is None:
+            log_err('Invalid public IP %s for rule reading' % args['src_ip'])
+            return False
+        args['af'], args['dst_ip'] = af_ip
+
+    # check source IP
+    if 'out_src_ip' in args and args['out_src_ip'] is not None:
+        af = args['af'] if 'af' in args else None
+        af_ip = check_ip_validity(af, args['out_src_ip'])
+        if af_ip is None:
+            log_err('Invalid outgoing source IP %s for rule reading' % args['out_src_ip'])
+            return False
+        args['af'], args['out_src_ip'] = af_ip
+
+    # check private IP
+    if 'private_ip' in args and args['private_ip'] is not None:
+        af = args['af'] if 'af' in args else None
+        af_ip = check_ip_validity(af, args['private_ip'])
+        if af_ip is None:
+            log_err('Invalid private IP %s for rule reading' % args['private_ip'])
+            return False
+        args['af'], args['private_ip'] = af_ip
+
+    log_info('Input parameters:')
+    for name, val in args.items():
+        if val is not None:
+            if name == 'dst_ip' or name == 'out_src_ip':
+                log_info('  %-10s - %s' % (name, binascii.hexlify(val)))
+            else:
+                log_info('  %-10s : %s' % (name, str(val)))
+
+    return process_vrf_outgoing_svcs_rule_get(resp, **args)
+
+
+def get_outgoing_ip_svcs_cb(methods, params):
+    try:
+        return get_outgoing_ip_svcs_int (methods, params)
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+
 if __name__ == '__main__':
 
     shutdown = False
@@ -606,12 +922,15 @@ if __name__ == '__main__':
     cps.obj_register(handle, _vrf_incoming_svc_config_key, d)
 
     d = {}
+    d['get'] = get_outgoing_ip_svcs_cb
     d['transaction'] = config_outgoing_ip_svcs_cb
     cps.obj_register(handle, _vrf_outgoing_svc_config_key, d)
 
     log_msg = 'CPS IP VRF registration done'
     log_info(log_msg)
 
+    dft_rule_ids = []
+    create_vrf_default_rules('default', rule_id_list = dft_rule_ids)
     process_pkt_reject_rule(True, 'default')
 
     # Notify systemd: Daemon is ready
@@ -626,3 +945,6 @@ if __name__ == '__main__':
     # No need to specifically call sys.exit(0).
     # That's the default behavior in Python.
     process_pkt_reject_rule(False, 'default')
+    for rule_id in dft_rule_ids:
+        log_info('Delete default ACl rule %d' % rule_id)
+        process_vrf_svcs_rule_del_by_id(rule_id)

--- a/scripts/lib/python/dn_base_mcast_snoop.py
+++ b/scripts/lib/python/dn_base_mcast_snoop.py
@@ -449,23 +449,31 @@ def monitor_VLAN_interface_event():
 
 def _parse_snoop_routes(vlan_id, vlan_info, op, igmp_events,group_info, pub_data):
 
+    oif_present = True
+
     for key, val in group_info.items():
       if 'group' not in val:
-        mcast_utils.log_err("Route Event: VLAN %d Group not present, skip processing" %(vlan_id))
+        mcast_utils.log_err("Route Event: VLAN %d, Group not present, skip processing" %(vlan_id))
         continue
       if 'interface' not in val:
-        mcast_utils.log_err("Route Event: VLAN %d interface not present, skip processing" %(vlan_id))
-        continue
+        mcast_utils.log_info("Route Event: VLAN %d, OIF not present, route with NULL OIF " %(vlan_id))
+        oif_present = False
+        interface = 'NULL'
 
-      interface = val['interface']
+      if oif_present:
+        interface = val['interface']
 
-      #Validate given interface is VLAN member
-      if mcast_utils.is_intf_vlan_member(vlan_info, interface, vlan_id) is False:
-        mcast_utils.log_err("Route Event: interface %s is not VLAN %d member, skip processing" %(str(interface),vlan_id))
-        if (op != "delete"):
-          return False
+        #Validate given interface is VLAN member
+        if mcast_utils.is_intf_vlan_member(vlan_info, interface, vlan_id) is False:
+          mcast_utils.log_err("Route Event: interface %s is not VLAN %d member, skip processing" %(str(interface),vlan_id))
+          if (op != "delete"):
+            return False
 
-        continue
+          continue
+
+        #Add interface/OIF only if its present, else its treated as route with NULL OIF
+        pub_data.update( {'vlan-id': vlan_id,
+            ('group', key, 'interface'): interface})
 
       if mcast_utils._is_ip_addr(igmp_events, val['group']):
         group = val['group']
@@ -475,7 +483,6 @@ def _parse_snoop_routes(vlan_id, vlan_info, op, igmp_events,group_info, pub_data
         group =  ba.ba_to_ipv6str('ipv6',val['group'])
 
       pub_data.update( {'vlan-id': vlan_id,
-            ('group', key, 'interface'): interface,
             ('group', key, 'address'): group})
 
       if 'source-addr' in val:

--- a/scripts/lib/python/dn_base_vrf_svcs_config.py
+++ b/scripts/lib/python/dn_base_vrf_svcs_config.py
@@ -13,11 +13,11 @@
 # permissions and limitations under the License.
 
 """
-This module provides support for caching VRF incoming IP rules, as well as rule
+This module provides support for caching VRF incoming & outgoing IP rules, as well as rule
 configuration through iptables
 """
 
-from dn_base_vrf_tool import iplink_cmd, run_command, log_info, log_err, rej_rule_mark_value
+from dn_base_vrf_tool import iplink_cmd, run_command, log_info, log_err, rej_rule_mark_value, _vrf_name_to_id
 from dn_base_id_tool import IdGenerator
 import cps_object
 import socket
@@ -27,27 +27,48 @@ import logging
 import copy
 import binascii
 from StringIO import StringIO
+from enum import IntEnum
 import re
 
 MGMT_VRF_ID = 1024
 
-""" Object to define one VRF incoming IP service rule """
-class VrfIncomingSvcsRule(object):
+""" Object to define VRF services rule definitions like
+    Type, Action, Protocol, Group Priority.
+"""
+class VrfSvcsRuleType(IntEnum):
     RULE_TYPE_IP = 1
     RULE_TYPE_ACL = 2
+    RULE_TYPE_OUT_IP = 3
+    RULE_TYPE_SNAT = 4
+
+class VrfSvcsRuleAction(IntEnum):
+    """ actions defined in model,
+        insert new action values per model before internal actions.
+    """
     RULE_ACTION_ALLOW = 1
     RULE_ACTION_DENY = 2
+    """ internal actions defined for kernel programming """
     RULE_ACTION_DNAT = 3
     RULE_ACTION_REJECT = 4
+    RULE_ACTION_SNAT = 5
+
+class VrfSvcsRuleProto(IntEnum):
     RULE_PROTO_TCP = 1
     RULE_PROTO_UDP = 2
     RULE_PROTO_ICMP = 3
+    RULE_PROTO_ALL = 4
 
+class VrfSvcsRuleGroupPrio(IntEnum):
     HIGH_GRP_PRIO = 1
     DEFAULT_GRP_PRIO = 10
 
+
+""" Object to define one VRF incoming IP service rule """
+class VrfIncomingSvcsRule(object):
+
     KEY_ATTRS = ['rule_type', 'vrf_name', 'af', 'src_ip', 'prefix_len',
-                 'protocol', 'dst_port', 'action', 'in_intf']
+                 'protocol', 'dst_port', 'low_dst_port', 'high_dst_port',
+                 'action', 'in_intf']
 
     @classmethod
     def is_rule_equal(cls, r1, r2):
@@ -62,8 +83,9 @@ class VrfIncomingSvcsRule(object):
         return True
 
     def __init__(self, rule_type, vrf_name, action, af, src_ip = None, prefix_len = None,
-                 protocol = None, dst_port = None, dst_ip = None, seq_num = 0, rule_id = None,
-                 high_prio = False, in_intf = None):
+                 protocol = None, dst_port = None, dst_ip = None, low_dst_port = None,
+                 high_dst_port = None, seq_num = 0, rule_id = None, high_prio = False,
+                 in_intf = None):
         """
         Constructor to create a ACL rule object
         @rule_type - either IP or ACL rule
@@ -72,8 +94,10 @@ class VrfIncomingSvcsRule(object):
         @af - address family, either IPv4 or IPv6, it could be direct number or string
         @src_ip - matched source IP address
         @prefix_len - prefix length to specify subnet
-        @protocol - IP protocol: 1: tcp, 2: udp, 3: icmp
+        @protocol - IP protocol: 1: tcp, 2: udp, 3: icmp, 4: all
         @dst_port - L4 destination port
+        @low_dst_port - lower L4 destination port (inclusive)
+        @high_dst_port - upper L4 destination port (inclusive)
         @dst_ip - specify destination IP when action is DNAT
         @seq_num - sequence number of the rule
         @rule_id - rule ID. it is optional
@@ -87,31 +111,33 @@ class VrfIncomingSvcsRule(object):
         self.prefix_len = prefix_len
         self.protocol = protocol
         self.dst_port = dst_port
+        self.low_dst_port = low_dst_port
+        self.high_dst_port = high_dst_port
         self.dst_ip = dst_ip
         self.seq_num = seq_num
         self.action = action
         self.grp_priority = high_prio
-        if self.action == self.RULE_ACTION_DNAT and self.dst_ip is None:
+        if self.action == VrfSvcsRuleAction.RULE_ACTION_DNAT and self.dst_ip is None:
             log_err('Destination IP is mandatory for DNAT action')
             raise ValueError
-        if self.action == self.RULE_ACTION_DENY and self.rule_type == self.RULE_TYPE_ACL:
+        if self.action == VrfSvcsRuleAction.RULE_ACTION_DENY and self.rule_type == VrfSvcsRuleType.RULE_TYPE_ACL:
             # For ACL rule, use REJECT action instead of DROP
-            self.action = self.RULE_ACTION_REJECT
+            self.action = VrfSvcsRuleAction.RULE_ACTION_REJECT
         self.rule_id = rule_id
         self.in_intf = in_intf
 
     def __setattr__(self, key, val):
         if key == 'grp_priority' and val is not None:
             if val:
-                val = self.HIGH_GRP_PRIO
+                val = VrfSvcsRuleGroupPrio.HIGH_GRP_PRIO
             else:
-                val = self.DEFAULT_GRP_PRIO
+                val = VrfSvcsRuleGroupPrio.DEFAULT_GRP_PRIO
         elif key == 'in_intf' and val is not None:
             if len(val) > 0 and val[0] == '!':
                 val = val[1:]
-                super(VrfIncomingSvcsRule, self).__setattr__('negtive', True)
+                super(VrfIncomingSvcsRule, self).__setattr__('negative', True)
             else:
-                super(VrfIncomingSvcsRule, self).__setattr__('negtive', False)
+                super(VrfIncomingSvcsRule, self).__setattr__('negative', False)
         super(VrfIncomingSvcsRule, self).__setattr__(key, val)
         if key == 'rule_type' and self.get_rule_type_name() is None:
             log_err('Invalid rule type %s' % str(self.rule_type))
@@ -143,8 +169,8 @@ class VrfIncomingSvcsRule(object):
         return hash_val
 
     def get_rule_type_name(self):
-        type_name_map = {self.RULE_TYPE_IP: 'IP',
-                         self.RULE_TYPE_ACL: 'ACL'}
+        type_name_map = {VrfSvcsRuleType.RULE_TYPE_IP: 'IP',
+                         VrfSvcsRuleType.RULE_TYPE_ACL: 'ACL'}
         if self.rule_type in type_name_map:
             return type_name_map[self.rule_type]
         else:
@@ -158,10 +184,10 @@ class VrfIncomingSvcsRule(object):
             return None
 
     def get_action_name(self, for_ipt_target = False):
-        action_name_map = {self.RULE_ACTION_ALLOW: ('allow', 'accept'),
-                           self.RULE_ACTION_DENY: ('deny', 'drop'),
-                           self.RULE_ACTION_DNAT: 'dnat',
-                           self.RULE_ACTION_REJECT: ('reject', 'mark')}
+        action_name_map = {VrfSvcsRuleAction.RULE_ACTION_ALLOW: ('allow', 'accept'),
+                           VrfSvcsRuleAction.RULE_ACTION_DENY: ('deny', 'drop'),
+                           VrfSvcsRuleAction.RULE_ACTION_DNAT: 'dnat',
+                           VrfSvcsRuleAction.RULE_ACTION_REJECT: ('reject', 'mark')}
         if self.action in action_name_map:
             action_name = action_name_map[self.action]
             if type(action_name) is tuple:
@@ -172,16 +198,17 @@ class VrfIncomingSvcsRule(object):
             return None
 
     def get_proto_name(self):
-        proto_name_map = {self.RULE_PROTO_TCP: 'tcp',
-                          self.RULE_PROTO_UDP: 'udp',
-                          self.RULE_PROTO_ICMP: 'icmp'}
+        proto_name_map = {VrfSvcsRuleProto.RULE_PROTO_TCP: 'tcp',
+                          VrfSvcsRuleProto.RULE_PROTO_UDP: 'udp',
+                          VrfSvcsRuleProto.RULE_PROTO_ICMP: 'icmp',
+                          VrfSvcsRuleProto.RULE_PROTO_ALL: 'ip'}
         if self.protocol in proto_name_map:
             return proto_name_map[self.protocol]
         else:
             return None
 
     def __str__(self):
-        ret_str =  ('%-3s %-8sVRF: %-10s SEQ: %2d-%-5d RULE: %-10s %s%s%s%s%s' %
+        ret_str =  ('%-5s %-8sVRF: %-10s SEQ: %5d-%-4d RULE: %-10s %s%s%s%s%s%s' %
                         (self.get_rule_type_name(),
                          ('-' if self.rule_id is None else ('%d' % self.rule_id)),
                          self.vrf_name, self.grp_priority, self.seq_num,
@@ -191,8 +218,10 @@ class VrfIncomingSvcsRule(object):
                             if self.src_ip is not None and self.prefix_len is not None else ''),
                          (' %s' % self.get_proto_name() if self.protocol is not None else ''),
                          (' dst_port %d' % self.dst_port if self.dst_port is not None else ''),
+                         (' dst_port range %d-%d' % (self.low_dst_port, self.high_dst_port) \
+                            if self.low_dst_port is not None else ''),
                          (' iif %s' % self.in_intf if self.in_intf is not None else '')))
-        if self.action == self.RULE_ACTION_DNAT:
+        if self.action == VrfSvcsRuleAction.RULE_ACTION_DNAT:
             ret_str += (' to %s' % socket.inet_ntop(self.af, self.dst_ip))
         return ret_str
 
@@ -204,17 +233,26 @@ class VrfIncomingSvcsRule(object):
             'prefix_len': 'src-prefix-len',
             'protocol': 'protocol',
             'dst_port': 'dst-port',
+            'low_dst_port': 'lower-dst-port',
+            'high_dst_port': 'upper-dst-port',
             'action': 'action',
             'seq_num': 'seq-num',
+            'in_intf': 'ifname',
             'rule_id': 'id'}
         obj = cps_object.CPSObject('vrf-firewall/ns-incoming-service')
         for attr_name, attr_val in vars(self).items():
             if attr_name in cps_attr_map and attr_val is not None:
-                if attr_name == 'action' and attr_val == self.RULE_ACTION_DNAT:
-                    # Always use allow action for DNAT
-                    attr_val = self.RULE_ACTION_ALLOW
+                if attr_name == 'action':
+                    if attr_val == VrfSvcsRuleAction.RULE_ACTION_DNAT:
+                        # Always use allow action for DNAT
+                        attr_val = VrfSvcsRuleAction.RULE_ACTION_ALLOW
+                    elif attr_val == VrfSvcsRuleAction.RULE_ACTION_REJECT:
+                        # Use deny action for cps get output
+                        attr_val = VrfSvcsRuleAction.RULE_ACTION_DENY
                 if attr_name == 'src_ip':
                     attr_val = binascii.hexlify(attr_val)
+                if attr_name == 'in_intf' and self.negative is True:
+                    attr_val = '!'+ attr_val
                 obj.add_attr(cps_attr_map[attr_name], attr_val)
         return obj
 
@@ -309,6 +347,7 @@ class VrfIncomingSvcsRuleList(list):
         del self.seq_num_list[:]
         self.rule_id_map.clear()
 
+#IP tables handler for both incoming & outgoing service configurations
 class IptablesHandler:
     @staticmethod
     def is_vrf_valid(vrf_name):
@@ -334,6 +373,12 @@ class IptablesHandler:
             log_info('VRF %s is not opened, bypass iptables setting.' % rule.vrf_name)
             return True
 
+        #@@@TODO - check if this below check is really needed
+        """ outgoing IP services rules are not allowed in default VRF """
+        if rule.vrf_name == 'default' and rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+            log_info('Invalid Rule. rule type %s not supported in VRF:%s.' % (rule.rule_type, rule.vrf_name))
+            return False
+
         if op == 'replace' and idx is None:
             log_err('Missing rule index for replace operation')
             return False
@@ -341,10 +386,22 @@ class IptablesHandler:
 
         if rule.vrf_name == 'default':
             ipt_prefix = ['/sbin/%s' % iptables]
-            tbl_name = (None if rule.rule_type == rule.RULE_TYPE_IP else 'raw')
+            #tbl_name = (None if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else 'raw')
+            if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP:
+                tbl_name = None
+            elif rule.rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+                tbl_name = 'nat'
+            else :
+                tbl_name = 'raw'
         else:
             ipt_prefix = [iplink_cmd, 'netns', 'exec', rule.vrf_name, iptables]
-            tbl_name = ('nat' if rule.rule_type == rule.RULE_TYPE_IP else 'raw')
+            #tbl_name = ('nat' if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else 'raw')
+            if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP or\
+                rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP or\
+                rule.rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+                tbl_name = 'nat'
+            else :
+                tbl_name = 'raw'
         if tbl_name is not None:
             ipt_prefix += ['-t', tbl_name]
 
@@ -354,26 +411,53 @@ class IptablesHandler:
                                         ('/%d' % rule.prefix_len if rule.prefix_len is not None else ''))]
         if rule.protocol is not None:
             flt_args += ['-p', rule.get_proto_name()]
-        if rule.dst_port is not None:
+
+        if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+            flt_args += ['--dport', str(rule.private_port)]
+        elif rule.dst_port is not None:
             flt_args += ['--dport', str(rule.dst_port)]
 
-        if rule.rule_type == rule.RULE_TYPE_IP:
+        if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_ACL and rule.low_dst_port is not None:
+            flt_args += ['--match', 'multiport', '--dports',
+                         '%s:%s' % (str(rule.low_dst_port), str(rule.high_dst_port))]
+
+        if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP:
             if rule.vrf_name == 'default':
                 flt_args += ['!', '-i', 'vdef-nsid%d' % MGMT_VRF_ID]
                 chain_name = 'INPUT'
             else:
                 chain_name = 'VRF'
+        elif rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+            vrf_id = None
+            vrf_id = _vrf_name_to_id.get(rule.vrf_name, None)
+            if vrf_id is not None:
+                flt_args += ['-i', 'veth-nsid%d'%vrf_id]
+            chain_name = 'PREROUTING'
+        elif rule.rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+            if rule.dst_ip is not None:
+                flt_args += ['--destination', '%s' % (socket.inet_ntop(rule.af, rule.dst_ip))]
+            #in management vrf, apply SNAT rules on interfaces other than internal veth interfaces.
+            #@@TODO - check how to handle for data vrf
+            if rule.vrf_name == 'management':
+                flt_args += ['!', '-o', 'veth-nsid%d' % MGMT_VRF_ID]
+            chain_name = 'POSTROUTING'
         else:
             chain_name = 'PREROUTING'
             if rule.in_intf is not None:
-                if rule.negtive:
+                if rule.negative:
                     flt_args.append('!')
                 flt_args += ['-i', rule.in_intf]
         flt_args += ['-j', rule.get_action_name(True).upper()]
-        if rule.action == rule.RULE_ACTION_DNAT:
-            flt_args += ['--to-destination', socket.inet_ntop(rule.af, rule.dst_ip)]
-        elif rule.action == rule.RULE_ACTION_REJECT:
+
+        if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+            flt_args += ['--to-destination',
+                         '%s:%s' % (socket.inet_ntop(rule.af, rule.dst_ip),str(rule.dst_port))]
+        elif rule.action == VrfSvcsRuleAction.RULE_ACTION_DNAT:
+            flt_args += ['--to-destination', '%s' % (socket.inet_ntop(rule.af, rule.dst_ip))]
+        elif rule.action == VrfSvcsRuleAction.RULE_ACTION_REJECT:
             flt_args += ['--set-mark', str(rej_rule_mark_value)]
+        elif rule.rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+            flt_args += ['--to-source', '%s' % (socket.inet_ntop(rule.af, rule.out_src_ip))]
 
         if op.lower() == 'insert':
             if idx is None:
@@ -403,6 +487,7 @@ class IptablesHandler:
         res = []
         return run_command(cmd, res, op.lower() != 'check') == 0
 
+
 class VrfIncomingSvcsRuleCache:
     # map: af, vrf_name => rule_list
     acl_rules = {socket.AF_INET: {}, socket.AF_INET6: {}}
@@ -414,7 +499,7 @@ class VrfIncomingSvcsRuleCache:
     def insert_rule(cls, rule):
         log_info('Handling add rule: %s' % rule)
         cls.mutex.acquire()
-        rule_list = cls.ip_rules[rule.af] if rule.rule_type == rule.RULE_TYPE_IP else cls.acl_rules[rule.af]
+        rule_list = cls.ip_rules[rule.af] if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[rule.af]
         if rule.vrf_name not in rule_list:
             rule_list[rule.vrf_name] = VrfIncomingSvcsRuleList()
         if rule.rule_id is None:
@@ -456,7 +541,7 @@ class VrfIncomingSvcsRuleCache:
     def delete_rule(cls, rule):
         log_info('Handling delete rule: %s' % rule)
         cls.mutex.acquire()
-        rule_list = cls.ip_rules[rule.af] if rule.rule_type == rule.RULE_TYPE_IP else cls.acl_rules[rule.af]
+        rule_list = cls.ip_rules[rule.af] if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[rule.af]
         if rule.vrf_name not in rule_list:
             log_err('VRF name %s not found in cache' % rule.vrf_name)
             cls.mutex.release()
@@ -508,7 +593,7 @@ class VrfIncomingSvcsRuleCache:
     @classmethod
     def find_rule_by_match(cls, rule):
         cls.mutex.acquire()
-        rule_list = cls.ip_rules[rule.af] if rule.rule_type == rule.RULE_TYPE_IP else cls.acl_rules[rule.af]
+        rule_list = cls.ip_rules[rule.af] if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[rule.af]
         if rule.vrf_name not in rule_list:
             cls.mutex.release()
             return None
@@ -528,7 +613,7 @@ class VrfIncomingSvcsRuleCache:
         if found_rule is not None:
             del_rule, idx = found_rule
             rule_list = cls.ip_rules[del_rule.af] \
-                if del_rule.rule_type == del_rule.RULE_TYPE_IP else cls.acl_rules[del_rule.af]
+                if del_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[del_rule.af]
             if rule_list[del_rule.vrf_name].remove_by_id(rule_id) is None:
                 log_err('Failed to remove rule with ID %d' % rule_id)
                 cls.mutex.release()
@@ -537,7 +622,7 @@ class VrfIncomingSvcsRuleCache:
                 log_err('Failed to call iptables to delete ACL rule')
                 # rollback
                 rule_list = cls.ip_rules[del_rule.af] \
-                    if del_rule.rule_type == del_rule.RULE_TYPE_IP else cls.acl_rules[del_rule.af]
+                    if del_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[del_rule.af]
                 rule_list[del_rule.vrf_name].insert(del_rule)
                 ret_val = False;
             if len(rule_list[del_rule.vrf_name]) == 0:
@@ -562,7 +647,7 @@ class VrfIncomingSvcsRuleCache:
         if found_rule is not None:
             old_rule, idx = found_rule
             rule_list = cls.ip_rules[old_rule.af] \
-                if old_rule.rule_type == old_rule.RULE_TYPE_IP else cls.acl_rules[old_rule.af]
+                if old_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_IP else cls.acl_rules[old_rule.af]
             if not IptablesHandler.proc_rule('replace', new_rule, idx):
                 log_err('Failed to call iptables to replace ACL rule')
                 ret_val = False;
@@ -618,7 +703,7 @@ class VrfIncomingSvcsRuleCache:
             cls.mutex.release()
             return False
 
-        repl_attrs = {'src_ip', 'prefix_len', 'protocol', 'dst_port', 'action', 'in_intf'}
+        repl_attrs = {'src_ip', 'prefix_len', 'protocol', 'dst_port', 'low_dst_port', 'high_dst_port', 'action', 'in_intf'}
         no_repl_attrs = changed_attrs.difference(repl_attrs)
         if len(no_repl_attrs) > 0:
             log_info('Non-replacable attributes %s changed, delete and add rule' % no_repl_attrs)
@@ -690,7 +775,7 @@ class VrfIncomingSvcsRuleCache:
         cls.mutex.acquire()
         ret_list = []
         for af in [socket.AF_INET, socket.AF_INET6]:
-            if rule_type is None or rule_type == VrfIncomingSvcsRule.RULE_TYPE_IP:
+            if rule_type is None or rule_type == VrfSvcsRuleType.RULE_TYPE_IP:
                 for vrf, rule_list in cls.ip_rules[af].items():
                     if vrf_name is not None and vrf != vrf_name:
                         continue
@@ -698,7 +783,7 @@ class VrfIncomingSvcsRuleCache:
                         if not rule.match(**params):
                             continue
                         ret_list.append(copy.deepcopy(rule))
-            if rule_type is None or rule_type == VrfIncomingSvcsRule.RULE_TYPE_ACL:
+            if rule_type is None or rule_type == VrfSvcsRuleType.RULE_TYPE_ACL:
                 for vrf, rule_list in cls.acl_rules[af].items():
                     if vrf_name is not None and vrf != vrf_name:
                         continue
@@ -778,3 +863,658 @@ def process_vrf_svcs_clear_rules(vrf_name = None):
         logging.exception(ex)
         return False
     return True
+
+
+""" Object to define one VRF outgoing IP service rule """
+class VrfOutgoingSvcsRule(object):
+
+    KEY_ATTRS = ['rule_type', 'vrf_name', 'af', 'dst_ip',
+                 'protocol', 'dst_port', 'out_src_ip']
+
+    @classmethod
+    def is_rule_equal(cls, r1, r2):
+        r1_attrs = vars(r1)
+        r2_attrs = vars(r2)
+        for key_attr in cls.KEY_ATTRS:
+            if key_attr in r1_attrs and key_attr in r2_attrs:
+                if r1_attrs[key_attr] != r2_attrs[key_attr]:
+                    return False
+            else:
+                return False
+        return True
+
+    def __init__(self, rule_type, vrf_name, action, af, dst_ip = None, protocol = None,
+                 dst_port = None, out_src_ip = None, private_ip = None, private_port = None,
+                 seq_num = 0, rule_id = None, high_prio = False):
+        """
+        Constructor to create a outgoing service IP rule object
+        @rule_type - either IP or SNAT rule
+        @vrf_name - namespace
+        @action - 1: dnat 2: snat
+        @af - address family, either IPv4 or IPv6, it could be direct number or string
+        @dst_ip - matched destination IP address
+        @protocol - IP protocol: 1: tcp, 2: udp, 3: icmp
+        @dst_port - L4 destination port
+        @out_src_ip - outgoing source IP when action is SNAT
+        @private_ip - private IP for outgoing IP services. it is optional
+        @private_port - private PORT for outgoing IP services. it is optional
+        @seq_num - sequence number of the rule. it is optional
+        @rule_id - rule ID. it is optional
+        @high_prio - if it is high priority rule
+        """
+        self.rule_type = rule_type
+        self.vrf_name = vrf_name
+        self.af = af
+        self.dst_ip = dst_ip
+        self.protocol = protocol
+        self.dst_port = dst_port
+        self.out_src_ip = out_src_ip
+        self.action = action
+        self.seq_num = seq_num
+        self.grp_priority = high_prio
+
+        # @@TODO - generate private_ip & private_port for IP rule
+        self.private_ip = private_ip
+        self.private_port = private_port
+
+        # @@TODO - following attributes are added to outgoing service rule,
+        # just to keep the rule common b/w incoming & outgoing service rule.
+        self.src_ip = None
+        if self.rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+            if self.action != VrfSvcsRuleAction.RULE_ACTION_SNAT:
+                log_err('for SNAT rule, action should be SNAT')
+                raise ValueError
+            if self.out_src_ip is None:
+                log_err('Outgoing Source IP is mandatory for SNAT action')
+                raise ValueError
+        self.rule_id = rule_id
+
+    def __setattr__(self, key, val):
+        if key == 'grp_priority' and val is not None:
+            if val:
+                val = VrfSvcsRuleGroupPrio.HIGH_GRP_PRIO
+            else:
+                val = VrfSvcsRuleGroupPrio.DEFAULT_GRP_PRIO
+        super(VrfOutgoingSvcsRule, self).__setattr__(key, val)
+        if key == 'rule_type' and self.get_rule_type_name() is None:
+            log_err('Invalid rule type %s' % str(self.rule_type))
+            raise ValueError
+        elif key == 'af' and self.get_af_name() is None:
+            log_err('Invalid address family number %s' % str(self.af))
+            raise ValueError
+        elif key == 'action' and self.get_action_name() is None:
+            log_err('Invalid action ID %s' % str(self.action))
+            raise ValueError
+
+        if val is not None:
+            if key == 'protocol' and self.get_proto_name() is None:
+                log_err('Invalid protocol number %s' % str(self.protocol))
+                raise ValueError
+
+    def __eq__(self, other):
+        return VrfOutgoingSvcsRule.is_rule_equal(self, other)
+
+    def __ne__(self, other):
+        return not VrfOutgoingSvcsRule.is_rule_equal(self, other)
+
+    def __hash__(self):
+        hash_val = 0
+        attrs = vars(self)
+        for key_attr in self.KEY_ATTRS:
+            if key_attr in attrs and attrs[key_attr] is not None:
+                hash_val ^= hash(attrs[key_attr])
+        return hash_val
+
+    def get_rule_type_name(self):
+        type_name_map = {VrfSvcsRuleType.RULE_TYPE_OUT_IP: 'IP',
+                         VrfSvcsRuleType.RULE_TYPE_SNAT: 'SNAT'}
+        if self.rule_type in type_name_map:
+            return type_name_map[self.rule_type]
+        else:
+            return None
+
+    def get_af_name(self):
+        af_name_map = {socket.AF_INET: 'IPv4', socket.AF_INET6: 'IPv6'}
+        if self.af in af_name_map:
+            return af_name_map[self.af]
+        else:
+            return None
+
+    def get_action_name(self, for_ipt_target = False):
+        action_name_map = {VrfSvcsRuleAction.RULE_ACTION_DNAT: 'dnat',
+                           VrfSvcsRuleAction.RULE_ACTION_SNAT: 'snat'}
+        if self.action in action_name_map:
+            action_name = action_name_map[self.action]
+            if type(action_name) is tuple:
+                return action_name[1] if for_ipt_target else action_name[0]
+            else:
+                return action_name
+        else:
+            return None
+
+    def get_proto_name(self):
+        proto_name_map = {VrfSvcsRuleProto.RULE_PROTO_TCP: 'tcp',
+                          VrfSvcsRuleProto.RULE_PROTO_UDP: 'udp',
+                          VrfSvcsRuleProto.RULE_PROTO_ICMP: 'icmp'}
+        if self.protocol in proto_name_map:
+            return proto_name_map[self.protocol]
+        else:
+            return None
+
+    def __str__(self):
+        ret_str =  ('%-5s %-8sVRF: %-10s SEQ: %5d-%-4d RULE: %-10s %s%s%s%s' %
+                        (self.get_rule_type_name(),
+                         ('-' if self.rule_id is None else ('%d' % self.rule_id)),
+                         self.vrf_name, self.grp_priority, self.seq_num,
+                         ('%s' % self.get_action_name() if self.action is not None else ''),
+                         self.get_af_name(),
+                         ('dst_ip %s' % (socket.inet_ntop(self.af, self.dst_ip))\
+                            if self.dst_ip is not None else ''),
+                         (' %s' % self.get_proto_name() if self.protocol is not None else ''),
+                         (' dst_port %d' % self.dst_port if self.dst_port is not None else '')))
+        if self.action == VrfSvcsRuleAction.RULE_ACTION_SNAT:
+            ret_str += ('%s' %
+                        ('outgoing source IP %s' % (socket.inet_ntop(self.af, self.out_src_ip) \
+                          if self.af is not None and self.out_src_ip is not None else '')))
+        if self.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+            ret_str += ('%s%s' %
+                        (('private-ip %s' % (socket.inet_ntop(self.af, self.private_ip) \
+                          if self.af is not None and self.private_ip is not None else '')),
+                        ('private-port %s' % (str(self.private_port) if self.private_port is not None else ''))))
+        return ret_str
+
+    def to_cps_obj(self):
+        cps_attr_map = {
+            'vrf_name': 'ni-name',
+            'af': 'af',
+            'dst_ip': 'public-ip',
+            'protocol': 'protocol',
+            'dst_port': 'public-port',
+            'out_src_ip': 'outgoing-source-ip',
+            'private_ip': 'private-ip',
+            'private_port': 'private-port',
+            'rule_id': 'id'}
+        obj = cps_object.CPSObject('vrf-firewall/ns-outgoing-service')
+        for attr_name, attr_val in vars(self).items():
+            if attr_name in cps_attr_map and attr_val is not None:
+                if attr_name == 'dst_ip' or attr_name == 'out_src_ip' or attr_name == 'private_ip':
+                    attr_val = binascii.hexlify(attr_val)
+                obj.add_attr(cps_attr_map[attr_name], attr_val)
+        return obj
+
+    def match(self, **params):
+        attrs = vars(self)
+        for key, val in params.items():
+            if key not in attrs:
+                return False
+            if val is not None and val != attrs[key]:
+                return False
+        return True
+
+class VrfOutgoingSvcsRuleList(list):
+    def __init__(self):
+        super(VrfOutgoingSvcsRuleList, self).__init__()
+        # sorted list of all seq num
+        self.seq_num_list = []
+        # map: rule_id => rule position in list
+        self.rule_id_map = {}
+
+    def __str__(self):
+        str_buf = StringIO()
+        for rule in self:
+            str_buf.write('%s\n' % rule)
+        out_str = str_buf.getvalue()
+        str_buf.close()
+        return out_str
+
+    def __eq__(self, other):
+        return super(VrfOutgoingSvcsRuleList, self).__eq__(other)
+
+    def __ne__(self, other):
+        return super(VrfOutgoingSvcsRuleList, self).__ne__(other)
+
+    def update_rule_id_map(self, start_idx):
+        for idx in range(start_idx, len(self)):
+            self.rule_id_map[self[idx].rule_id] = idx
+
+    # insert rule to list, update seq_num list and rule_id map
+    def insert(self, rule):
+        if rule.rule_id is None or rule.rule_id in self.rule_id_map:
+            # rule ID should be assigned and not used by another rule
+            log_err('Rule ID is not assigned' if rule.rule_id is None
+                    else ('Rule ID %d is used' % rule.rule_id))
+            return None
+        try:
+            idx = self.index(rule)
+        except ValueError:
+            idx = None
+        if idx is not None:
+            # same rule already in list
+            log_err('Rule to be inserted is already in list')
+            return None
+        idx = bisect.bisect_right(self.seq_num_list, (rule.grp_priority, rule.seq_num))
+        super(VrfOutgoingSvcsRuleList, self).insert(idx, rule)
+        self.seq_num_list.insert(idx, (rule.grp_priority, rule.seq_num))
+        self.update_rule_id_map(idx)
+        return idx
+
+    def remove(self, rule):
+        if rule.rule_id is not None and rule.rule_id in self.rule_id_map:
+            idx = self.rule_id_map[rule.rule_id]
+            rule_id = rule.rule_id
+        else:
+            try:
+                idx = self.index(rule)
+            except ValueError:
+                # rule not found
+                log_err('Rule not found for delete')
+                return None
+            rule_id = self[idx].rule_id
+        orig_rule = self[idx]
+        del self[idx]
+        del self.seq_num_list[idx]
+        del self.rule_id_map[rule_id]
+        self.update_rule_id_map(idx)
+        return (orig_rule, idx)
+
+    def remove_by_id(self, rule_id):
+        if rule_id not in self.rule_id_map:
+            return None
+        idx = self.rule_id_map[rule_id]
+        orig_rule = self[idx]
+        del self[idx]
+        del self.seq_num_list[idx]
+        del self.rule_id_map[rule_id]
+        self.update_rule_id_map(idx)
+        return orig_rule
+
+    def clear(self):
+        del self[:]
+        del self.seq_num_list[:]
+        self.rule_id_map.clear()
+
+
+class VrfOutgoingSvcsRuleCache:
+    # map: af, vrf_name => rule_list
+    snat_rules = {socket.AF_INET: {}, socket.AF_INET6: {}}
+    ip_rules = {socket.AF_INET: {}, socket.AF_INET6: {}}
+    mutex = threading.RLock()
+    id_generator = IdGenerator()
+
+    @classmethod
+    def insert_rule(cls, rule):
+        log_info('Handling add rule: %s' % rule)
+        cls.mutex.acquire()
+        rule_list = cls.ip_rules[rule.af]\
+            if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP else cls.snat_rules[rule.af]
+        if rule.vrf_name not in rule_list:
+            rule_list[rule.vrf_name] = VrfOutgoingSvcsRuleList()
+        if rule.rule_id is None:
+            rule.rule_id = cls.id_generator.get_new_id()
+            if rule.rule_id is None:
+                log_err('Could not generate new rule ID')
+                log_info(str(cls.id_generator))
+                cls.mutex.release()
+                return False
+        else:
+            if cls.id_generator.is_id_used(rule.rule_id):
+                log_err('Given rule ID %d is used' % rule.rule_id)
+                log_info(str(cls.id_generator))
+                cls.mutex.release()
+                return False
+            if not cls.id_generator.reserve_id(rule.rule_id):
+                log_err('Failed to reserve rule ID %d' % rule.rule_id)
+                log_info(str(cls.id_generator))
+                cls.mutex.release()
+                return False
+        ret_val = True
+        idx = rule_list[rule.vrf_name].insert(rule)
+        if idx is not None:
+            if not IptablesHandler.proc_rule('insert', rule, idx):
+                log_err('Failed to call iptables to insert rule')
+                cls.id_generator.release_id(rule.rule_id)
+                # rollback
+                rule_list[rule.vrf_name].remove(rule)
+                ret_val = False
+        else:
+            log_err('Failed to insert rule to cache')
+            cls.id_generator.release_id(rule.rule_id)
+            ret_val = False
+        cls.mutex.release()
+        if ret_val:
+            log_info('Rule added, ID=%d' % rule.rule_id)
+        return ret_val
+
+    @classmethod
+    def delete_rule(cls, rule):
+        log_info('Handling delete rule: %s' % rule)
+        cls.mutex.acquire()
+        rule_list = cls.ip_rules[rule.af]\
+            if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP else cls.snat_rules[rule.af]
+        if rule.vrf_name not in rule_list:
+            log_err('VRF name %s not found in cache' % rule.vrf_name)
+            cls.mutex.release()
+            return False
+        ret_val = rule_list[rule.vrf_name].remove(rule)
+        if ret_val is None:
+            log_err('Failed to delete rule from cache')
+            cls.mutex.release()
+            return False
+        del_rule, idx = ret_val
+        ret_val = True
+        if not IptablesHandler.proc_rule('delete', del_rule, idx):
+            log_err('Failed to call iptables to delete rule')
+            # rollback
+            rule_list[del_rule.vrf_name].insert(del_rule)
+            ret_val = False
+        if len(rule_list[rule.vrf_name]) == 0:
+            del rule_list[rule.vrf_name]
+        cls.mutex.release()
+        if ret_val:
+            if not cls.id_generator.release_id(del_rule.rule_id):
+                log_err('Failed to release rule ID %d' % del_rule.rule_id)
+                log_info(str(cls.id_generator))
+            log_info('Rule deleted')
+        return ret_val
+
+    @classmethod
+    def find_rule_by_id(cls, rule_id):
+        ret_val = None
+        cls.mutex.acquire()
+        for af in [socket.AF_INET, socket.AF_INET6]:
+            for vrf_name, rule_list in cls.ip_rules[af].items():
+                if rule_id in rule_list.rule_id_map:
+                    idx = rule_list.rule_id_map[rule_id]
+                    ret_val = (rule_list[idx], idx)
+                    break
+            if ret_val is not None:
+                break
+            for vrf_name, rule_list in cls.snat_rules[af].items():
+                if rule_id in rule_list.rule_id_map:
+                    idx = rule_list.rule_id_map[rule_id]
+                    ret_val = (rule_list[idx], idx)
+                    break
+            if ret_val is not None:
+                break
+        cls.mutex.release()
+        return ret_val
+
+    @classmethod
+    def find_rule_by_match(cls, rule):
+        cls.mutex.acquire()
+        rule_list = cls.ip_rules[rule.af] if rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP else cls.snat_rules[rule.af]
+        if rule.vrf_name not in rule_list:
+            cls.mutex.release()
+            return None
+        try:
+            idx = rule_list[rule.vrf_name].index(rule)
+        except ValueError:
+            cls.mutex.release()
+            return None
+        return rule_list[rule.vrf_name][idx]
+
+    @classmethod
+    def delete_rule_by_id(cls, rule_id):
+        log_info('Handling delete rule by ID: %d' % rule_id)
+        cls.mutex.acquire()
+        ret_val = True
+        found_rule = cls.find_rule_by_id(rule_id)
+        if found_rule is not None:
+            del_rule, idx = found_rule
+            rule_list = cls.ip_rules[del_rule.af] \
+                if del_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP \
+                else cls.snat_rules[del_rule.af]
+            if rule_list[del_rule.vrf_name].remove_by_id(rule_id) is None:
+                log_err('Failed to remove rule with ID %d' % rule_id)
+                cls.mutex.release()
+                return False
+            if not IptablesHandler.proc_rule('delete', del_rule, idx):
+                log_err('Failed to call iptables to delete rule')
+                # rollback
+                rule_list = cls.ip_rules[del_rule.af] \
+                    if del_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP \
+                    else cls.snat_rules[del_rule.af]
+                rule_list[del_rule.vrf_name].insert(del_rule)
+                ret_val = False;
+            if len(rule_list[del_rule.vrf_name]) == 0:
+                del rule_list[del_rule.vrf_name]
+        else:
+            log_err('Rule ID %d not found for delete' % rule_id)
+            ret_val = False
+        cls.mutex.release()
+        if ret_val:
+            if not cls.id_generator.release_id(rule_id):
+                log_err('Failed to release rule ID %d' % rule_id)
+                log_info(str(cls.id_generator))
+            log_info('Rule deleted')
+        return ret_val
+
+    @classmethod
+    def replace_rule(cls, rule_id, new_rule):
+        log_info('Handling replace rule with ID %d' % rule_id)
+        cls.mutex.acquire()
+        ret_val = True
+        found_rule = cls.find_rule_by_id(rule_id)
+        if found_rule is not None:
+            old_rule, idx = found_rule
+            rule_list = cls.ip_rules[old_rule.af] \
+                if old_rule.rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP else cls.snat_rules[old_rule.af]
+            if not IptablesHandler.proc_rule('replace', new_rule, idx):
+                log_err('Failed to call iptables to replace rule')
+                ret_val = False;
+            else:
+                rule_list[old_rule.vrf_name][idx] = new_rule
+        else:
+            log_err('Rule ID %d not found for replace' % rule_id)
+            ret_val = False
+        cls.mutex.release()
+        if ret_val:
+            log_info('Rule replaced')
+        return ret_val
+
+    @classmethod
+    def update_rule(cls, rule_id, **params):
+        log_info('Handling update rule: ID %d param %s' % (rule_id, params))
+        cls.mutex.acquire()
+        found_rule = cls.find_rule_by_id(rule_id)
+        if found_rule is None:
+            log_err('Rule ID %d not found for update' % rule_id)
+            cls.mutex.release()
+            return False
+        old_rule, _ = found_rule
+        upd_rule = copy.deepcopy(old_rule)
+        changed_attrs = set()
+
+        def check_and_set(rule, key, val):
+            try:
+                orig_val = getattr(rule, key)
+            except AttributeError:
+                orig_val = None
+            if val != orig_val:
+                if val is not None:
+                    setattr(rule, key, val)
+                else:
+                    delattr(rule, key)
+                changed_attrs.add(key)
+
+        for key, val in params.items():
+            if val is not None:
+                check_and_set(upd_rule, key, val)
+        if len(changed_attrs) == 0:
+            log_info('There is no change to be updated, just return')
+            cls.mutex.release()
+            return True
+
+        log_info('old_rule: %s' % old_rule)
+        log_info('new_rule: %s' % upd_rule)
+
+        match_rule = cls.find_rule_by_match(upd_rule)
+        if match_rule is not None and match_rule.rule_id != old_rule.rule_id:
+            log_err('The updating rule already exists')
+            cls.mutex.release()
+            return False
+
+        repl_attrs = {'dst_ip', 'dst_port', 'out_src_ip', 'action'}
+        no_repl_attrs = changed_attrs.difference(repl_attrs)
+        if len(no_repl_attrs) > 0:
+            log_info('Non-replacable attributes %s changed, delete and add rule' % no_repl_attrs)
+            if not cls.delete_rule_by_id(rule_id):
+                log_err('Failed to delete existing rule by ID')
+                cls.mutex.release()
+                return False
+
+            ret_val = cls.insert_rule(upd_rule)
+            if not ret_val:
+                log_err('Failed to insert updated rule')
+                cls.insert_rule(old_rule)
+        else:
+            log_info('Only replacable attributes changed, just replace rule')
+            ret_val = cls.replace_rule(rule_id, upd_rule)
+            if not ret_val:
+                log_err('Failed to replace rule')
+        cls.mutex.release()
+        if ret_val:
+            log_info('Rule updated')
+        return ret_val
+
+    @classmethod
+    #@@TODO - when clearing outgoing service binding rules, release the private port mapping
+    def clear_all_rules(cls, flt_vrf = None, flt_af = None):
+        log_info('Handling clear all rules for VRF %s and AF %s' % (
+                    flt_vrf if flt_vrf is not None else '-',
+                    str(flt_af) if flt_af is not None else '-'))
+        cls.mutex.acquire()
+        for af in [socket.AF_INET, socket.AF_INET6]:
+            if flt_af is not None and flt_af != af:
+                continue
+            for vrf_name, rule_list in cls.ip_rules[af].items():
+                if flt_vrf is not None and flt_vrf != vrf_name:
+                    continue
+                for rule in rule_list:
+                    IptablesHandler.proc_rule('delete', rule)
+                    cls.id_generator.release_id(rule.rule_id)
+                rule_list.clear()
+                del cls.ip_rules[af][vrf_name]
+            for vrf_name, rule_list in cls.snat_rules[af].items():
+                if flt_vrf is not None and flt_vrf != vrf_name:
+                    continue
+                for rule in rule_list:
+                    IptablesHandler.proc_rule('delete', rule)
+                    cls.id_generator.release_id(rule.rule_id)
+                rule_list.clear()
+                del cls.snat_rules[af][vrf_name]
+        cls.mutex.release()
+
+    @classmethod
+    def dump_rules(cls):
+        cls.mutex.acquire()
+        for af in [socket.AF_INET, socket.AF_INET6]:
+            for vrf_name, rule_list in cls.ip_rules[af].items():
+                log_info('-------------------------------------')
+                log_info(' %s IP Rules of VRF %s' % ('IPv4' if af == socket.AF_INET else 'IPv6', vrf_name))
+                log_info('-------------------------------------')
+                log_info('\n%s\n' % rule_list)
+            for vrf_name, rule_list in cls.snat_rules[af].items():
+                log_info('-------------------------------------')
+                log_info(' %s SNAT Rules of VRF %s' % ('IPv4' if af == socket.AF_INET else 'IPv6', vrf_name))
+                log_info('--------------------------------------')
+                log_info('\n%s\n' % rule_list)
+        cls.mutex.release()
+
+    @classmethod
+    def get_all_rules(cls, rule_type = None, vrf_name = None, **params):
+        log_info('Handling get rules for vrf %s' % (vrf_name if vrf_name is not None else 'ALL'))
+        cls.mutex.acquire()
+        ret_list = []
+        for af in [socket.AF_INET, socket.AF_INET6]:
+            if rule_type is None or rule_type == VrfSvcsRuleType.RULE_TYPE_OUT_IP:
+                for vrf, rule_list in cls.ip_rules[af].items():
+                    if vrf_name is not None and vrf != vrf_name:
+                        continue
+                    for rule in rule_list:
+                        if not rule.match(**params):
+                            continue
+                        ret_list.append(copy.deepcopy(rule))
+            if rule_type is None or rule_type == VrfSvcsRuleType.RULE_TYPE_SNAT:
+                for vrf, rule_list in cls.snat_rules[af].items():
+                    if vrf_name is not None and vrf != vrf_name:
+                        continue
+                    for rule in rule_list:
+                        if not rule.match(**params):
+                            continue
+                        ret_list.append(copy.deepcopy(rule))
+        cls.mutex.release()
+        return ret_list
+
+
+def process_vrf_outgoing_svcs_rule_add(rule_type, vrf_name, action, af, **params):
+    try:
+        rule = VrfOutgoingSvcsRule(rule_type, vrf_name, action, af, **params)
+        if not VrfOutgoingSvcsRuleCache.insert_rule(rule):
+            return None
+    except ValueError:
+        log_err('Failed to initiate rule object')
+        return None
+    except Exception as ex:
+        logging.exception(ex)
+        return None
+    return rule.rule_id
+
+def process_vrf_outgoing_svcs_rule_set(rule_id, **params):
+    try:
+        if not VrfOutgoingSvcsRuleCache.update_rule(rule_id, **params):
+            return False
+    except ValueError:
+        log_err('Failed to update rule with params: %s' % params)
+        return False
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+    return True
+
+def process_vrf_outgoing_svcs_rule_del(rule_type, vrf_name, action, af, **params):
+    try:
+        rule = VrfOutgoingSvcsRule(rule_type, vrf_name, action, af, **params)
+        if not VrfOutgoingSvcsRuleCache.delete_rule(rule):
+            return None
+    except ValueError:
+        log_err('Failed to initiate rule object')
+        return False
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+    return True
+
+def process_vrf_outgoing_svcs_rule_del_by_id(rule_id):
+    try:
+        if not VrfOutgoingSvcsRuleCache.delete_rule_by_id(rule_id):
+            return False
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+    return True
+
+def process_vrf_outgoing_svcs_rule_get(resp, rule_id = None, rule_type = None, vrf_name = None, **params):
+    try:
+        if rule_id is not None:
+            found_rule = VrfOutgoingSvcsRuleCache.find_rule_by_id(rule_id)
+            if found_rule is not None:
+                resp.append(found_rule[0].to_cps_obj().get())
+        else:
+            rule_list = VrfOutgoingSvcsRuleCache.get_all_rules(rule_type, vrf_name, **params)
+            for rule in rule_list:
+                resp.append(rule.to_cps_obj().get())
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+    return True
+
+def process_vrf_outgoing_svcs_clear_rules(vrf_name = None):
+    try:
+        VrfOutgoingSvcsRuleCache.clear_all_rules(vrf_name)
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+    return True
+
+

--- a/src/nas_os_ip.cpp
+++ b/src/nas_os_ip.cpp
@@ -235,6 +235,12 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
             EV_LOGGING(NAS_OS, ERR, "IP-PUB",
                        "Interface %d to if_name from OS returned error",
                        ifmsg->ifa_index);
+            if (rt_msg_type == RTM_DELADDR)  {
+                /* @@TODO Once the local intf cache supports intf-index to intf-name get, fill the below attributes,
+                 * in case of intf. del, this util which gets the intf-name from kernel fails,
+                 * and the IP addr del pub is ignored here, for now, allow it. */
+                return true;
+            }
             return false;
         }
 

--- a/src/nas_os_l3.c
+++ b/src/nas_os_l3.c
@@ -579,7 +579,8 @@ cps_api_return_code_t nas_os_update_route (cps_api_object_t obj, nas_rt_msg_type
                 }
                 if (intf_ctrl.int_type == nas_int_type_MGMT) {
                     int if_index = 0;
-                    if (nas_os_util_int_if_index_get(vrf_name, intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
+                    if (nas_os_util_int_if_index_get((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME),
+                                                     intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
                         EV_LOGGING(NAS_OS, ERR, "ROUTE-UPD",
                                    "Interface %s to if_index from OS returned error",
                                    intf_ctrl.if_name);
@@ -669,7 +670,8 @@ cps_api_return_code_t nas_os_update_route (cps_api_object_t obj, nas_rt_msg_type
                     }
                     if (intf_ctrl.int_type == nas_int_type_MGMT) {
                         int if_index = 0;
-                        if (nas_os_util_int_if_index_get(vrf_name, intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
+                        if (nas_os_util_int_if_index_get((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME),
+                                                         intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
                             EV_LOGGING(NAS_OS, ERR, "ROUTE-UPD",
                                        "Interface %s to if_index from OS returned error",
                                        intf_ctrl.if_name);
@@ -711,7 +713,7 @@ cps_api_return_code_t nas_os_update_route (cps_api_object_t obj, nas_rt_msg_type
 
     do  {
 
-        rc = nl_do_set_request(vrf_name, nas_nl_sock_T_ROUTE,nlh,buff1,sizeof(buff1));
+        rc = nl_do_set_request((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME), nas_nl_sock_T_ROUTE,nlh,buff1,sizeof(buff1));
         nhm_count--;
         err_code = STD_ERR_EXT_PRIV (rc);
         EV_LOGGING(NAS_OS, INFO,"ROUE_UPD","Netlink error_code %d", err_code);
@@ -760,7 +762,7 @@ t_std_error nas_os_update_route_nexthop (cps_api_object_t obj)
 
     memset(buff,0,sizeof(struct nlmsghdr));
 
-    const char *vrf_name           = cps_api_object_get_data(obj,BASE_ROUTE_OBJ_VRF_NAME);
+    const char *vrf_name           = cps_api_object_get_data(obj, BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_VRF_NAME);
     cps_api_object_attr_t prefix   = cps_api_object_attr_get(obj, BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_ROUTE_PREFIX);
     cps_api_object_attr_t af       = cps_api_object_attr_get(obj, BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_AF);
     cps_api_object_attr_t pref_len = cps_api_object_attr_get(obj, BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_PREFIX_LEN);
@@ -826,8 +828,8 @@ t_std_error nas_os_update_route_nexthop (cps_api_object_t obj)
     uint32_t addr_len = (rm->rtm_family == AF_INET)?HAL_INET4_LEN:HAL_INET6_LEN;
     nlmsg_add_attr(nlh,sizeof(buff),RTA_DST,cps_api_object_attr_data_bin(prefix),addr_len);
 
-    EV_LOGGING(NAS_OS, INFO, "ROUTE-NH-UPD","NH count:%d family:%s msg:%s for prefix:%s len:%d proto:%d scope:%d type:%d",
-               nhc,
+    EV_LOGGING(NAS_OS, INFO, "ROUTE-NH-UPD","VRF:%s NH count:%d family:%s msg:%s for prefix:%s len:%d proto:%d scope:%d type:%d",
+               (vrf_name ? vrf_name : ""), nhc,
                ((rm->rtm_family == AF_INET) ? "IPv4" : "IPv6"),
                ((m_type == NAS_RT_DEL) ? "Route-Delete-NH" : "Route-Append-NH"),
                ((rm->rtm_family == AF_INET) ?
@@ -960,7 +962,7 @@ t_std_error nas_os_update_route_nexthop (cps_api_object_t obj)
 
     int err_code;
 
-    rc = nl_do_set_request(vrf_name, nas_nl_sock_T_ROUTE,nlh,buff1,sizeof(buff1));
+    rc = nl_do_set_request((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME), nas_nl_sock_T_ROUTE,nlh,buff1,sizeof(buff1));
 
     err_code = STD_ERR_EXT_PRIV (rc);
     EV_LOGGING (NAS_OS, INFO, "ROUE-NH-UPD","Netlink error_code %d", err_code);
@@ -1072,7 +1074,7 @@ cps_api_return_code_t nas_os_update_neighbor(cps_api_object_t obj, nas_rt_msg_ty
         }
         if (intf_ctrl.int_type == nas_int_type_MGMT) {
             int if_index = 0;
-            if (nas_os_util_int_if_index_get(vrf_name, intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
+            if (nas_os_util_int_if_index_get((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME), intf_ctrl.if_name, &if_index) != STD_ERR_OK) {
                 EV_LOGGING(NAS_OS, ERR, "NEIGH-UPD",
                            "Interface %s to if_index from OS returned error",
                            intf_ctrl.if_name);
@@ -1140,7 +1142,7 @@ cps_api_return_code_t nas_os_update_neighbor(cps_api_object_t obj, nas_rt_msg_ty
         nlmsg_add_attr(nlh,sizeof(buff),NDA_LLADDR, &mac_addr, HAL_MAC_ADDR_LEN);
     }
 
-    t_std_error rc = nl_do_set_request(vrf_name, nas_nl_sock_T_NEI,nlh,buff,sizeof(buff));
+    t_std_error rc = nl_do_set_request((vrf_name ? vrf_name : NAS_DEFAULT_VRF_NAME), nas_nl_sock_T_NEI,nlh,buff,sizeof(buff));
     int err_code = STD_ERR_EXT_PRIV (rc);
     char mac_buff[MAC_STRING_LEN];
     memset(mac_buff, '\0', sizeof(mac_buff));
@@ -1148,7 +1150,7 @@ cps_api_return_code_t nas_os_update_neighbor(cps_api_object_t obj, nas_rt_msg_ty
     EV_LOGGING(NAS_OS, INFO,"NEIGH-UPD","Operation:%s VRF:%s family:%s NH:%s MAC:%s out-intf:%d state:%s rc:%d",
                ((m_type == NAS_RT_DEL) ? "Arp-Del" : ((m_type == NAS_RT_ADD) ? "Arp-Add" :
                                                       ((m_type == NAS_RT_REFRESH) ? "Arp-Refresh" : "Arp-Replace"))),
-               vrf_name,
+               (vrf_name ? vrf_name : ""),
                ((ndm->ndm_family == AF_INET) ? "IPv4" : "IPv6"),
                ((ndm->ndm_family == AF_INET) ?
                 (inet_ntop(ndm->ndm_family, cps_api_object_attr_data_bin(ip), addr_str, INET_ADDRSTRLEN)) :

--- a/src/unit_test/nas_mcast_snoop_app_ut.cpp
+++ b/src/unit_test/nas_mcast_snoop_app_ut.cpp
@@ -27,6 +27,7 @@
 #include "cps_api_object_key.h"
 #include "cps_api_events.h"
 #include "ietf-igmp-mld-snooping.h"
+#include "std_utils.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -200,10 +201,11 @@ static void _parse_snoop_routes(cps_api_object_it_t &itor, int event_type)
             if (grp_attr_id == group_if_id) {
                 const char *if_name = (char *)cps_api_object_attr_data_bin(grp_it.attr);
                 cout<<"Multicast route OIF "<< if_name<<endl;
+                safestrncpy(received_oif, if_name,sizeof(received_oif));
             } else if (grp_attr_id == group_addr_id) {
                 const char *ip_addr_str = (const char *)cps_api_object_attr_data_bin(grp_it.attr);
                 cout<<"Multicast route group address "<<ip_addr_str<<endl;
-                strncpy(received_grp_ip, ip_addr_str,sizeof(received_grp_ip));
+                safestrncpy(received_grp_ip, ip_addr_str,sizeof(received_grp_ip));
             } else if (grp_attr_id == group_src_id) {
                 cps_api_object_it_t in_grp_it = grp_it;
                 cps_api_object_it_inside(&in_grp_it);
@@ -215,7 +217,7 @@ static void _parse_snoop_routes(cps_api_object_it_t &itor, int event_type)
                         if (src_attr_id == group_src_addr_id) {
                             const char *src_ip_str = (const char *)cps_api_object_attr_data_bin(src_it.attr);
                             cout<<"Multicast route group source address :"<< src_ip_str<<endl;
-                            strncpy(received_src_ip, src_ip_str,sizeof(received_src_ip));
+                            safestrncpy(received_src_ip, src_ip_str,sizeof(received_src_ip));
                         }
                     }
                 }
@@ -292,7 +294,7 @@ static bool _ut_mc_event_handler(cps_api_object_t evt_obj, void *param)
          cps_api_object_it_next(&it)) {
         cps_api_attr_id_t attr_id = cps_api_object_attr_id(it.attr);
         if (attr_id == mrouter_id) {
-                strncpy(received_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
+                safestrncpy(received_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
                         sizeof(received_mrouter_ifname));
                 cout<<"Handling mrouter event VLAN: "<<received_vlan<<
                          " mrouter interface: "<<received_mrouter_ifname<<endl;
@@ -432,19 +434,22 @@ static bool _set_snoop_igmp_route(int vlan, const char *grp, const char *src,
    cps_api_object_t commit_obj = cps_api_object_create();
    igmp_obj(commit_obj, vlan, true);
 
-   cps_api_attr_id_t ids[3] = {IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP, 0, IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP_INTERFACE};
-   if (!cps_api_object_e_add(commit_obj, ids, 3, cps_api_object_ATTR_T_BIN, rt_oif, strlen(rt_oif)+ 1)){
-       cout << "Failed to set mc entry interface name" <<endl;
-       cps_api_object_delete(commit_obj);
-       return false;
-   }
-   ids[2] = IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP_GROUP;
+   /* group is mandatory */
+   cps_api_attr_id_t ids[3] = {IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP, 0, IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP_GROUP};
    if (!cps_api_object_e_add(commit_obj, ids, 3, cps_api_object_ATTR_T_BIN, grp, strlen(grp)+ 1)) {
        cout << "Failed to set mc entry group IP address" <<endl;
        cps_api_object_delete(commit_obj);
        return false;
    }
-
+   /* OIF can be NULL */
+   if (rt_oif) {
+      ids[2] = IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP_INTERFACE;
+      if (!cps_api_object_e_add(commit_obj, ids, 3, cps_api_object_ATTR_T_BIN, rt_oif, strlen(rt_oif)+ 1)){
+          cout << "Failed to set mc entry interface name" <<endl;
+          cps_api_object_delete(commit_obj);
+          return false;
+      }
+   }
    if (src != NULL) {
       ids[2] = IGMP_MLD_SNOOPING_RT_ROUTING_CONTROL_PLANE_PROTOCOLS_IGMP_SNOOPING_VLANS_VLAN_STATIC_L2_MULTICAST_GROUP_SOURCE_ADDR;
       if (!cps_api_object_e_add(commit_obj, ids, 3, cps_api_object_ATTR_T_BIN, src, strlen(src) + 1)) {
@@ -461,13 +466,16 @@ static bool _set_snoop_igmp_route(int vlan, const char *grp, const char *src,
    sleep(1);
 
    if((received_op != op) && (strcmp(grp,received_grp_ip) != 0) && (vlan != received_vlan) &&
-      (strcmp(rt_oif, received_oif) != 0) && ((src != NULL) && (strcmp(src,received_src_ip) != 0))) {
+      ((rt_oif != NULL) && (strcmp(rt_oif, received_oif) != 0)) && ((src != NULL) && (strcmp(src,received_src_ip) != 0))) {
      cout<<"Failed to match VLAN "<<vlan<<" Grp: "<<grp<<" Src: "<<src<<" OIF: "<<rt_oif<<" Op: "<<op<<endl;
      return false;
    }
 
    if (src) {
-     cout<<"Matched VLAN "<<vlan<<" Grp: "<<grp<<"Src: "<<src <<" OIF: "<<rt_oif<<" Op: "<<op<<endl;
+     if (rt_oif)
+       cout<<"Matched VLAN "<<vlan<<" Grp: "<<grp<<" Src: "<<src <<" OIF: "<<rt_oif <<" Op: "<<op<<endl;
+     else
+       cout<<"Matched VLAN "<<vlan<<" Grp: "<<grp<<" Src: "<<src <<" OIF: "<< "NULL" <<" Op: "<<op<<endl;
    }
    else {
      cout<<"Matched VLAN "<<vlan<<" Grp: "<<grp<<" OIF: "<<rt_oif<<" Op: "<<op<<endl;
@@ -547,6 +555,11 @@ TEST(std_mcast_snoop_app_test, mcast_snoop_igmp_route) {
        ASSERT_TRUE(0);
     }
 
+    /* (S,G) route with NULL OIF */
+    if(_set_snoop_igmp_route(vlan, grp_ip,src_ip, NULL, cps_api_oper_CREATE) == 0) {
+       ASSERT_TRUE(0);
+    }
+
     /* (*,G) route */
     if(_set_snoop_igmp_route(vlan, grp_ip,NULL, oif, cps_api_oper_DELETE) == 0) {
        ASSERT_TRUE(0);
@@ -554,6 +567,11 @@ TEST(std_mcast_snoop_app_test, mcast_snoop_igmp_route) {
 
     /* (S,G) route */
     if(_set_snoop_igmp_route(vlan, grp_ip,src_ip, oif, cps_api_oper_DELETE) == 0) {
+       ASSERT_TRUE(0);
+    }
+
+    /* (S,G) route with NULL OIF */
+    if(_set_snoop_igmp_route(vlan, grp_ip,src_ip, NULL, cps_api_oper_DELETE) == 0) {
        ASSERT_TRUE(0);
     }
 }

--- a/src/unit_test/scripts/ip_addr_config_unittest.py
+++ b/src/unit_test/scripts/ip_addr_config_unittest.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+import cps
+import cps_object
+import cps_utils
+import dn_base_ip_tool
+
+def get_if_info_ipv4():
+    bcast_addr = ""
+    res = []
+    cmd = ['ifconfig', 'e101-001-0']
+    if dn_base_ip_tool.run_command(cmd, res) == 0:
+        ip_info = res[1].split()
+        if 'broadcast' in ip_info:
+            bcast_addr = ip_info[-1]
+
+    return bcast_addr
+
+def get_ipv6_addr_flag():
+    res = []
+    cmd = ['ifconfig', 'br1']
+    if dn_base_ip_tool.run_command(cmd, res) != 0:
+        assert 0
+
+    flag = "not_seen"
+    for e in res:
+        if "101:101:101:101:101:101:101:101" in e:
+            flag = "seen"
+
+    return flag
+
+def ip_add_verify(address_family, prefix_length):
+
+    if address_family == "ipv4":
+        bcast_addr = get_if_info_ipv4()
+
+        addr = {
+                    "8": "1.255.255.255",
+                    "16": "1.1.255.255",
+                    "24" : "1.1.1.255",
+                    "32" : "0.0.0.0"
+                }
+        assert bcast_addr == addr[prefix_length]
+
+    elif address_family == "ipv6":
+        flag = get_ipv6_addr_flag()
+        assert flag == "seen"
+
+    else:
+        print "Unsupported address family"
+        assert 0
+
+
+def ip_delete_verify(address_family, prefix_length):
+    if address_family == "ipv4":
+        bcast_addr = get_if_info_ipv4()
+        assert bcast_addr == ""
+    elif address_family == "ipv6":
+        flag = get_ipv6_addr_flag()
+        assert flag == "not_seen"
+    else:
+        print "Unsupported address family"
+        assert 0
+
+def ip_address_config(operation, address_family, prefix_length):
+    if address_family == "ipv4":
+        mod = "base-ip/ipv4/address"
+        name_attr = "base-ip/ipv4/name"
+        name = "e101-001-0"
+        ip_addr = "01010101"
+
+    elif address_family == "ipv6":
+        mod = "base-ip/ipv6/address"
+        name_attr = "base-ip/ipv6/name"
+        name = "br1"
+        ip_addr = "01010101010101010101010101010101"
+    else:
+        print "Unsupported address family"
+        assert 0
+
+    cps_obj = cps_object.CPSObject(module = mod)
+    cps_obj.add_attr(name_attr, name)
+    cps_obj.add_attr('ip', ip_addr)
+    cps_obj.add_attr('prefix-length', prefix_length)
+
+    ch = {'operation': operation, 'change': cps_obj.get()}
+
+    if cps.transaction([ch]):
+        print "Success"
+        cps_utils.print_obj(ch['change'])
+
+    if operation == "create":
+        ip_add_verify(address_family, prefix_length)
+    elif operation == "delete":
+        ip_delete_verify(address_family, prefix_length)
+    else:
+        print "Unsupported operation"
+
+def test_ip_address_config():
+    ip_address_config("create", "ipv4", "8")
+    ip_address_config("delete", "ipv4", "8")
+
+    ip_address_config("create", "ipv4", "16")
+    ip_address_config("delete", "ipv4", "16")
+
+    ip_address_config("create", "ipv4", "24")
+    ip_address_config("delete", "ipv4", "24")
+
+    ip_address_config("create", "ipv4", "32")
+    ip_address_config("delete", "ipv4", "32")
+
+
+    ip_address_config("create", "ipv6", "64")
+    ip_address_config("delete", "ipv6", "64")
+
+    ip_address_config("create", "ipv6", "128")
+    ip_address_config("delete", "ipv6", "128")
+

--- a/src/unit_test/scripts/nas_outgoing_svcs_ut.py
+++ b/src/unit_test/scripts/nas_outgoing_svcs_ut.py
@@ -1,0 +1,332 @@
+#!/usr/bin/python
+
+import cps
+import cps_object
+import cps_utils
+import sys
+import subprocess
+import argparse
+import socket
+import time
+import binascii
+
+"""
+Example:
+nas_outgoing_svcs_ut.py create -f ipv4 --dest-ip 1.1.1.1 -p tcp -d 41 --out-src-ip 8.8.8.8
+nas_outgoing_svcs_ut.py delete -f ipv4 --dest-ip 1.1.1.1 -p tcp -d 41 --out-src-ip 8.8.8.8
+nas_outgoing_svcs_ut.py info
+nas_outgoing_svcs_ut.py create -f ipv4 --dest-ip 2.2.2.2 -p tcp -d 51 --out-src-ip 9.9.9.9
+nas_outgoing_svcs_ut.py delete 1
+
+nas_outgoing_svcs_ut.py create -n default -f ipv4 --dest-ip 3.3.3.3 -p tcp -d 61 --out-src-ip 8.1.1.1
+nas_outgoing_svcs_ut.py default -n default -f ipv4 --dest-ip 3.3.3.3 -p tcp -d 61 --out-src-ip 8.1.1.1
+nas_outgoing_svcs_ut.py create -n management -f ipv4 --dest-ip 3.3.3.3 -p tcp -d 61 --out-src-ip 8.1.1.1
+nas_outgoing_svcs_ut.py default -n management -f ipv4 --dest-ip 3.3.3.3 -p tcp -d 61 --out-src-ip 8.1.1.1
+
+"""
+
+def parse_ip_mask(key, val):
+    ip_mask = val.split('/')
+    if len(ip_mask) < 2:
+        ip_addr = ip_mask[0]
+    else:
+        ip_addr, mask = ip_mask[:2]
+    for af in [socket.AF_INET, socket.AF_INET6]:
+        try:
+            ip_bin = socket.inet_pton(af, ip_addr)
+            return (af, binascii.hexlify(ip_bin))
+        except socket.error:
+            continue
+    return None
+
+def parse_af(key, val):
+    if val.lower() == 'ipv4':
+        return socket.AF_INET
+    else:
+        return socket.AF_INET6
+
+def parse_protocol(key, val):
+    if val.lower() == 'tcp':
+        return 1
+    elif val.lower() == 'udp':
+        return 2
+    elif val.lower() == 'icmp':
+        return 3
+    else:
+        return 4
+
+arg_cps_attr_map = {
+    'rule_id': ('id', None),
+    'vrf_name': ('ni-name', None),
+    'addr_family': ('af', parse_af),
+    'protocol': ('protocol', parse_protocol),
+    'dst_port': ('public-port', None),
+    'dest_ip': (['af', 'public-ip'], parse_ip_mask),
+    'out_src_ip': (['af', 'outgoing-source-ip'], parse_ip_mask),
+    'priv_port': ('private-port', None),
+    'priv_ip': (['af', 'private-ip'], parse_ip_mask)
+}
+
+def exec_shell(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    return out
+
+def test_pre_req_cfg(clear = False, mgmt_ip = '10.11.70.22/8'):
+    #config test pre requisite - manangement vrf
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+        mode = 'DoD'
+
+    if mode is 'DoD':
+        #configure the test pre requisites via CLI
+        if clear:
+            cmd_list =  ['configure terminal',
+                         'interface mgmt1/1/1',
+                         'no ip address',
+                         'exit',
+                         'ip vrf management',
+                         'no interface management',
+                         'exit',
+                         'no ip vrf management',
+                         'interface mgmt1/1/1',
+                         'ip address ' + mgmt_ip,
+                         'end']
+        else:
+            cmd_list =  ['configure terminal',
+                         'interface mgmt1/1/1',
+                         'no ip address',
+                         'no ipv6 address',
+                         'exit',
+                         'ip vrf management',
+                         'interface management',
+                         'exit',
+                         'interface mgmt1/1/1',
+                         'ip address ' + mgmt_ip,
+                         'end']
+        cfg_file = open('/tmp/test_pre_req', 'w')
+        for item in cmd_list:
+            print>>cfg_file, item
+        cfg_file.close()
+        exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+        print 'UT for BASE is not supported yet.'
+
+
+parser = argparse.ArgumentParser(description = 'Tool for Outgoing IP service configuration')
+parser.add_argument('operation', choices = ['create', 'delete', 'set', 'info', 'pre-cfg', 'run-test'])
+parser.add_argument('rule_id', type = int, nargs = '?', help = 'Rule ID')
+parser.add_argument('--clear', action = 'store_true', help = 'Cleanup pre-configuration for testing')
+parser.add_argument('--mgmt-ip', help = 'Management IP address and mask for testing')
+parser.add_argument('-n', '--vrf-name',  default = 'default', help = 'VRF name')
+parser.add_argument('-f', '--addr-family', choices = ['ipv4', 'ipv6'], help = 'Address family')
+parser.add_argument('-p', '--protocol', choices = ['tcp', 'udp', 'icmp', 'all'], help = 'Protocol')
+parser.add_argument('-d', '--dst-port', type = int, help = 'L4 destination port')
+parser.add_argument('-i', '--seq-num', type = int, help = 'Sequence number')
+parser.add_argument('-dip', '--dest-ip', help = 'Destination IP address')
+parser.add_argument('-sip', '--out-src-ip', help = 'Outgoing Source IP address')
+parser.add_argument('--private-ip', help = 'Private IP address')
+parser.add_argument('--private-port', type = int, help = 'Private L4 destination port')
+
+test_count = 0
+
+def outgoing_svcs_test(is_negative_test = False, *test_args):
+    global parser
+    global test_count
+
+    if len(test_args) == 0:
+        args = vars(parser.parse_args())
+    else:
+        args = vars(parser.parse_args(test_args))
+
+    op = args['operation']
+
+    if op == 'pre-cfg':
+        #config test pre-req
+        clear = args['clear']
+        print 'Running test pre-configruation %s...' % ('cleanup ' if clear else '')
+        if 'mgmt_ip' in args and args['mgmt_ip'] is not None:
+            print 'Management IP: %s' % args['mgmt_ip']
+            test_pre_req_cfg(clear, args['mgmt_ip'])
+        else:
+            test_pre_req_cfg(clear)
+        time.sleep(20)
+        print 'Done with pre-configuration'
+        return True
+
+    obj = cps_object.CPSObject('vrf-firewall/ns-outgoing-service')
+    for arg_name, arg_val in args.items():
+        if arg_name in arg_cps_attr_map and arg_val is not None:
+            attr_name, func = arg_cps_attr_map[arg_name]
+            if func is not None:
+                attr_val = func(arg_name, arg_val)
+                if type(attr_name) is list:
+                    if attr_val is None:
+                        raise RuntimeError('Failed to convert input %s' % arg_name)
+                    if len(attr_name) != len(attr_val):
+                        raise RuntimeError('Invalid argument %s' % arg_name)
+                    for idx in range(len(attr_name)):
+                        if attr_val[idx] is not None:
+                            obj.add_attr(attr_name[idx], attr_val[idx])
+                else:
+                    if attr_val is not None:
+                        obj.add_attr(attr_name, attr_val)
+            else:
+                obj.add_attr(attr_name, arg_val)
+
+    if op == 'info':
+        ret_list = []
+        if cps.get([obj.get()], ret_list) == False:
+            raise RuntimeError('Failed to get object')
+        # exit on success for negative test
+        # when obj get returned empty list, return false
+        if not ret_list and is_negative_test is False:
+            print 'Info get failed'
+            raise RuntimeError('Failed to get object')
+        if ret_list and is_negative_test is True:
+            print 'Info get returned incorrect info'
+            raise RuntimeError('Failed to get correct object')
+        for ret_obj in ret_list:
+            cps_utils.print_obj(ret_obj)
+    elif op == 'run-test':
+        if run_test_outgoing_svcs() == False:
+            print 'UT failed'
+            sys.exit(1)
+        print 'UT success'
+        return True
+    else:
+        upd = (op, obj.get())
+        ret_val = cps_utils.CPSTransaction([upd]).commit()
+        # exit on success for negative test
+        if is_negative_test and ret_val != False:
+            raise RuntimeError('Operation %s should have failed but succeed' % op)
+        elif not is_negative_test and ret_val == False:
+            raise RuntimeError('Failed to %s object' % op)
+        if ret_val != False:
+            print 'Input object %s' % op
+            cps_utils.print_obj(ret_val[0])
+    test_count += 1
+    return True
+
+def run_test_outgoing_svcs():
+    #print 'info before run-test'
+    #print '--------------------'
+    #outgoing_svcs_test(False, "info")
+    #print '--------------------'
+
+    try:
+        # test w/o any vrf name
+        outgoing_svcs_test(False, "create", "-f", "ipv4", "-dip", "1.1.1.1", "-p", "tcp", "-d", "41", "-sip", "8.8.8.8")
+        outgoing_svcs_test(False, "create", "-f", "ipv4", "-dip", "2.2.2.2", "-p", "tcp", "-d", "51", "-sip", "9.9.9.9")
+        outgoing_svcs_test(False, "info", "-f", "ipv4", "-dip", "1.1.1.1", "-p", "tcp", "-d", "41", "-sip", "8.8.8.8")
+        outgoing_svcs_test(False, "info", "-f", "ipv4", "-dip", "2.2.2.2", "-p", "tcp", "-d", "51", "-sip", "9.9.9.9")
+        outgoing_svcs_test(False, "delete", "-f", "ipv4", "-dip", "1.1.1.1", "-p", "tcp", "-d", "41", "-sip", "8.8.8.8")
+        outgoing_svcs_test(False, "delete", "-f", "ipv4", "-dip", "2.2.2.2", "-p", "tcp", "-d", "51", "-sip", "9.9.9.9")
+        outgoing_svcs_test(True, "info", "-f", "ipv4", "-dip", "1.1.1.1", "-p", "tcp", "-d", "41", "-sip", "8.8.8.8")
+        outgoing_svcs_test(True, "info", "-f", "ipv4", "-dip", "2.2.2.2", "-p", "tcp", "-d", "51", "-sip", "9.9.9.9")
+
+        # test for different protocol
+        outgoing_svcs_test(False, "create", "-f", "ipv4", "-dip", "1.1.2.1", "-p", "udp", "-d", "41", "-sip", "8.1.1.1")
+        outgoing_svcs_test(False, "info", "-f", "ipv4", "-dip", "1.1.2.1", "-p", "udp", "-d", "41", "-sip", "8.1.1.1")
+        outgoing_svcs_test(False, "delete", "-f", "ipv4", "-dip", "1.1.2.1", "-p", "udp", "-d", "41", "-sip", "8.1.1.1")
+        outgoing_svcs_test(True, "info", "-f", "ipv4", "-dip", "1.1.2.1", "-p", "udp", "-d", "41", "-sip", "8.1.1.1")
+
+        # test for config with vrf name
+        outgoing_svcs_test(False, "create", "-n", "default", "-f", "ipv4", "-dip", "1.1.4.1", "-p", "udp", "-d", "42", "-sip", "8.1.1.2")
+        outgoing_svcs_test(False, "create", "-n", "default", "-f", "ipv4", "-dip", "1.1.5.1", "-p", "tcp", "-d", "52", "-sip", "9.1.1.2")
+        outgoing_svcs_test(False, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.4.1", "-p", "udp", "-d", "42", "-sip", "8.1.1.2")
+        outgoing_svcs_test(False, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.5.1", "-p", "tcp", "-d", "52", "-sip", "9.1.1.2")
+        outgoing_svcs_test(False, "delete", "-n", "default", "-f", "ipv4", "-dip", "1.1.4.1", "-p", "udp", "-d", "42", "-sip", "8.1.1.2")
+        outgoing_svcs_test(False, "delete", "-n", "default", "-f", "ipv4", "-dip", "1.1.5.1", "-p", "tcp", "-d", "52", "-sip", "9.1.1.2")
+        outgoing_svcs_test(True, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.4.1", "-p", "udp", "-d", "42", "-sip", "8.1.1.2")
+        outgoing_svcs_test(True, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.5.1", "-p", "tcp", "-d", "52", "-sip", "9.1.1.2")
+
+        # test for config with management vrf name
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.6.1", "-p", "udp", "-d", "43", "-sip", "8.1.1.3")
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.7.1", "-p", "tcp", "-d", "53", "-sip", "9.1.1.3")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.6.1", "-p", "udp", "-d", "43", "-sip", "8.1.1.3")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.7.1", "-p", "tcp", "-d", "53", "-sip", "9.1.1.3")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.6.1", "-p", "udp", "-d", "43", "-sip", "8.1.1.3")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.7.1", "-p", "tcp", "-d", "53", "-sip", "9.1.1.3")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.6.1", "-p", "udp", "-d", "43", "-sip", "8.1.1.3")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.7.1", "-p", "tcp", "-d", "53", "-sip", "9.1.1.3")
+
+
+        # test for create w/o vrf name and validate for entry with 'default' vrf name
+        outgoing_svcs_test(False, "create", "-f", "ipv4", "-dip", "1.1.8.1", "-p", "tcp", "-d", "44", "-sip", "8.1.1.4")
+        outgoing_svcs_test(False, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.8.1", "-p", "tcp", "-d", "44", "-sip", "8.1.1.4")
+        outgoing_svcs_test(False, "delete", "-f", "ipv4", "-dip", "1.1.8.1", "-p", "tcp", "-d", "44", "-sip", "8.1.1.4")
+        outgoing_svcs_test(True, "info", "-f", "ipv4", "-dip", "1.1.8.1", "-p", "tcp", "-d", "44", "-sip", "8.1.1.4")
+
+        # test for create with 'default' vrf name and validate for entry w/o vrf name
+        outgoing_svcs_test(False, "create", "-n", "default", "-f", "ipv4", "-dip", "1.1.9.1", "-p", "tcp", "-d", "45", "-sip", "8.1.1.5")
+        outgoing_svcs_test(False, "info", "-f", "ipv4", "-dip", "1.1.9.1", "-p", "tcp", "-d", "45", "-sip", "8.1.1.5")
+        outgoing_svcs_test(False, "delete", "-f", "ipv4", "-dip", "1.1.9.1", "-p", "tcp", "-d", "45", "-sip", "8.1.1.5")
+        outgoing_svcs_test(True, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.9.1", "-p", "tcp", "-d", "45", "-sip", "8.1.1.5")
+
+        ## Negative test
+        # Duplicate create (this rule should be created by application as default)
+        outgoing_svcs_test(False, "create", "-n", "default", "-f", "ipv4", "-dip", "1.1.10.1", "-p", "tcp", "-d", "46", "-sip", "8.1.1.6")
+        outgoing_svcs_test(True, "create", "-n", "default", "-f", "ipv4", "-dip", "1.1.10.1", "-p", "tcp", "-d", "46", "-sip", "8.1.1.6")
+        outgoing_svcs_test(False, "info", "-n", "default", "-f", "ipv4", "-dip", "1.1.10.1", "-p", "tcp", "-d", "46", "-sip", "8.1.1.6")
+        outgoing_svcs_test(False, "delete", "-n", "default", "-f", "ipv4", "-dip", "1.1.10.1", "-p", "tcp", "-d", "46", "-sip", "8.1.1.6")
+        # Delete non-existent rule
+        outgoing_svcs_test(True, "delete", "-n", "default", "-f", "ipv4", "-dip", "1.1.10.1", "-p", "tcp", "-d", "46", "-sip", "8.1.1.6")
+
+        ## test for service binding rules
+
+        # test for service binding rules - outgoing service DNAT rules
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "udp", "-d", "121")
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "tcp", "-d", "122")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "udp", "-d", "121", "--private-ip", "127.100.100.2", "--private-port", "62000")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "tcp", "-d", "122", "--private-ip", "127.100.100.2", "--private-port", "62001")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "udp", "-d", "121")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "tcp", "-d", "122")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "udp", "-d", "121", "--private-ip", "127.100.100.2", "--private-port", "62000")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.11.1", "-p", "tcp", "-d", "122", "--private-ip", "127.100.100.2", "--private-port", "62001")
+
+        # test for service binding rule & SNAT rule
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123")
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123", "-sip", "8.1.1.7")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123", "--private-ip", "127.100.100.2", "--private-port", "62000")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123", "-sip", "8.1.1.7")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123", "-sip", "8.1.1.7")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.12.1", "-p", "udp", "-d", "123", "-sip", "8.1.1.7")
+
+        # test for service binding rule & SNAT rule and operations involving service binding rules
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124")
+        outgoing_svcs_test(False, "create", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "-sip", "8.1.1.8")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "--private-ip", "127.100.100.2", "--private-port", "62000")
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "-sip", "8.1.1.8")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124")
+        #delete of service binding rule should not delete outgoing source ip rule
+        outgoing_svcs_test(False, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "-sip", "8.1.1.8")
+        outgoing_svcs_test(True, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124")
+        outgoing_svcs_test(False, "delete", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "-sip", "8.1.1.8")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124")
+        outgoing_svcs_test(True, "info", "-n", "management", "-f", "ipv4", "-dip", "1.1.13.1", "-p", "tcp", "-d", "124", "-sip", "8.1.1.8")
+
+
+    except RuntimeError as ex:
+        print 'UT failed: %s' % ex
+        return False
+    finally:
+        print 'Finished tests: %d' % test_count
+
+    #print 'info after run-test'
+    #print '--------------------'
+    #outgoing_svcs_test(False, "info")
+    #print '--------------------'
+    print 'All UT finished'
+    return True
+
+
+if __name__ == '__main__':
+    try:
+        outgoing_svcs_test()
+    except RuntimeError as ex:
+        print 'Failed: %s' % ex
+        sys.exit(1)


### PR DESCRIPTION
  * Bugfix: Non-default VRF with MASQURADE option should not change the source IP of the forwarded traffic.
  * Bugfix: Kernel is not updated with the CoPP ACL destination address correctly.
  * Update: Cleanup vrf-firewall outgoing service model that handles service binding config.
            Ensuring proper handling of private ip/port allocation/de-allocation.
  * Update: Support for dst_ip filter type for COPP ACL
  * Bugfix: Added rule to drop all flooded queries except the general queries.
  * Bugfix: Support for oper. status publish thru BASE_IF_LINUX_IF_INTERFACES_INTERFACE_IF_FLAGS
            CPS attribute from NAS-linux.
  * Update: Added support for CPS Get query on IP address, based on non-default VRF name filter.
  * Update: Added support to handle snoop routes with no OIF(out going interfaces).
  * Update: Added support for outgoing source address translation as part of ns-outgoing-service model.
  * Update: Added UT scripts for outgoing service configuration.
  * Update: Added interface attribute to incoming service model to support rule configuration on a specific port.
  * Update: Added broadcast address during IP address configuration.
  * Update: Added support for L4 destination port range for CoPP ACL.
  * Update: Added default accept rule for lo interface to default netns.
  * Bugfux: Fix ping failure after unconfigure and re-configure.

Signed-off-by: Rakesh Datta <rakesh.datta6@gmail.com>