### PR TITLE
Fix: Python script dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-linux], [5.24.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-linux], [5.24.0+opx1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+opx-nas-linux (5.24.0+opx1) unstable; urgency=medium
+
+  * Bugfix: Fix package dependency issue.
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 11 Sep 2018 19:25:43 -0800
+
 opx-nas-linux (5.24.0) unstable; urgency=medium
 
   * Update: Remove ack flag from interface config in netlink.
   * Bugfix: Default route is not removed from management-route table,
-            after IP address is released from the DHCP Server for the Management-VRF. 
+            after IP address is released from the DHCP Server for the Management-VRF.
   * Update: Use a fixed VRF-id (1024) for mgmt VRF while publishing the connected route event.
   * Bugfix: Non-default VRF with MASQUERADE option is changing the source IP of the forwarded traffic.
   * Update: Cleanup vrf-firewall outgoing service model for handling service binding config.
@@ -16,16 +22,16 @@ opx-nas-linux (5.24.0) unstable; urgency=medium
 opx-nas-linux (5.22.0) unstable; urgency=medium
 
   * Bugfix: Non-default VRF with MASQURADE option should not change the source IP of the forwarded traffic.
-  * Bugfix: Kernel is not updated with the CoPP ACL destination address correctly. 
+  * Bugfix: Kernel is not updated with the CoPP ACL destination address correctly.
   * Update: Cleanup vrf-firewall outgoing service model that handles service binding config.
             Ensuring proper handling of private ip/port allocation/de-allocation.
   * Update: Support for dst_ip filter type for COPP ACL
   * Bugfix: Added rule to drop all flooded queries except the general queries.
-  * Bugfix: Support for oper. status publish thru BASE_IF_LINUX_IF_INTERFACES_INTERFACE_IF_FLAGS 
+  * Bugfix: Support for oper. status publish thru BASE_IF_LINUX_IF_INTERFACES_INTERFACE_IF_FLAGS
             CPS attribute from NAS-linux.
-  * Update: Added support for CPS Get query on IP address, based on non-default VRF name filter. 
+  * Update: Added support for CPS Get query on IP address, based on non-default VRF name filter.
   * Update: Added support to handle snoop routes with no OIF(out going interfaces).
-  * Update: Added support for outgoing source address translation as part of ns-outgoing-service model. 
+  * Update: Added support for outgoing source address translation as part of ns-outgoing-service model.
   * Update: Added UT scripts for outgoing service configuration.
   * Update: Added interface attribute to incoming service model to support rule configuration on a specific port.
   * Update: Added broadcast address during IP address configuration.
@@ -80,7 +86,7 @@ opx-nas-linux (5.11.0+opx2) unstable; urgency=medium
 
 opx-nas-linux (5.11.0+opx1) unstable; urgency=medium
 
-  * Update: Add support for loopback interface get/set handler. 
+  * Update: Add support for loopback interface get/set handler.
   * Update: Add comments to describe dummy interface.
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 31 Jan 2017 14:56:43 -0800
@@ -137,7 +143,7 @@ opx-nas-linux (5.3.0) unstable; urgency=medium
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 29 Sep 2017 20:56:43 -0700
 
 opx-nas-linux (4.8.0) unstable; urgency=medium
- 
+
   * Update: Support for disabling IPv6 on VLAN member ports
   * Update: Netlink socket buffer sizes defined based on the number of netlink events generated from the kernel
   * Update: FDB Nbr netlink info published from NAS-Linux

--- a/debian/control
+++ b/debian/control
@@ -22,5 +22,5 @@ Description: This package contains the Linux integration portion of the Network 
 
 Package: opx-nas-linux
 Architecture: any
-Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2)
+Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2), python-ipaddress (>= 1.0.17-1), python-enum34 (>= 1.1.6-1)
 Description: This package contains the Linux integration portion of the Network abstractions service.


### PR DESCRIPTION
Updated debian/control file to include to modules that are dependencies
for a vrf script (base_vrf.py).

Signed-off-by: Garrick He <garrick_he@dell.com>