### PR TITLE
feat: opx-3.2.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -31,6 +31,7 @@ LD_HARDEN_FLAGS=-Wl,-z,defs -Wl,-z,now
 libopx_nas_linux_la_SOURCES=src/nas_os_int_utils.c src/nas_os_vlan_utils.c src/db_linux_interface.c src/net_main.cpp src/netlink_tools.c src/db_linux_route.c src/ds_linux_init.c src/ds_interface_name_tools.c src/ds_api_linux_neigh.c src/nas_os_vlan.cpp src/nas_os_lag.c src/nas_os_interface.cpp src/nas_os_stg.cpp src/nas_os_l3.c src/nas_os_ip.cpp src/nas_os_mac.cpp src/netlink_stats.cpp src/if/os_interface_macvlan.cpp src/nas_os_mcast_snoop.cpp src/nas_os_vrf.cpp
 
 libopx_nas_linux_la_SOURCES+=src/if/os_interface_cache.cpp src/if/os_interface_lag.cpp src/if/os_interface_vlan.cpp src/if/os_interface.cpp src/if/os_interface_stg.cpp src/if/os_interface_loopback.cpp src/if/os_interface_bridge.cpp src/if/os_interface_cache_utils.cpp src/if/os_interface_vxlan.cpp \
+src/nas_os_lpbk.cpp \
 src/if/os_interface_mgmt.cpp
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,11 +13,10 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 #
-
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-linux], [5.25.0+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-linux], [5.28.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+opx-nas-linux (5.28.0) unstable; urgency=medium
+
+  * Update: publish FDB event with master index for remote MAC entry
+  * Update: disabling ipv6 config on sub interface in OS.
+  * Update: code changes to set admin status of all sub interfaces before handling the parent 
+            interface admin state, when parent interface needs to be shutdown.
+  * Update: avoid checking vlan Id in case of remote mac
+  * Bugfix: nas journal logs cleanup
+  * Feature: dhcp v4 and v6 snooping
+  * Feature: APIs to support loopback control in nas-linux
+  * Update: avoid the reserved IP address logs and fixed the module for journal log
+  * Bugfix: fixed the error logs for reserved IP address filter
+  * Update: management-vrf : install the ip/ip6 table rule based on source ip
+  * Update: If_type check is not required when the mgmt intf is getting associated with mgmt VRF
+  * Update: do not log an error when the LLA is configured from address handling thread.
+  * Update: added handling for icmpv6 protocol type
+  * Update: added the default VRF-id check for the interface util functions that are meant only for default VRF.
+  * Update: using id_generator_t to get the next unused vrf id. 
+  * Update: update only the non-zero parent interface in the lower layer intf attribute while publishing the nbr event.
+  * Update: ignore route netlink events from OS if the route configurations are expected with CPS object from App
+  * Update: APIs to support loopback control in nas-linux
+  * Update: disable snooping in kernel for 1d bridges(Similar to 1Q bridges).
+  * Update: clearing per-vlan SAI stats
+  * Update: base mcast default journal logs
+  * Bugfix: management vrf - eth0 accepts junk packets if the destIP is not eth0's IP
+  * Update: copyright year
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 06 Jun 2019 19:25:43 -0800
+
 opx-nas-linux (5.25.0+opx3) unstable; urgency=medium
 
   * Update: README copyright placement
@@ -196,7 +225,7 @@ opx-nas-linux (4.8.0) unstable; urgency=medium
   * Update: Added support for handling management vlan
   * Update: Handling IPv6 neighbor flush on IPv6 address delete
 
- -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 21 June 2017 20:56:43 -0700
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 21 Jun 2017 20:56:43 -0700
 
 opx-nas-linux (1.0.1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Dell EMC <ops-dev@lists.openswitch.net>
 Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev (>= 1.4.0),libopx-nas-common-dev (>= 6.1.0),
-            libopx-cps-dev (>= 3.6.2),libopx-base-model-dev (>= 3.148.0),libopx-logging-dev (>= 2.1.0)
+            libopx-cps-dev (>= 3.6.2),libopx-base-model-dev (>= 3.109.0),libopx-logging-dev (>= 2.1.0)
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-linux
 Vcs-Git: https://github.com/open-switch/opx-nas-linux.git
@@ -17,10 +17,10 @@ Description: This package contains the Linux integration portion of the Network 
 Package: libopx-nas-linux-dev
 Architecture: any
 Depends: ${misc:Depends},libopx-common-dev (>= 1.4.0),libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),
-        libopx-nas-common-dev (>= 6.1.0),libopx-base-model-dev (>= 3.148.0),libopx-nas-linux1 (=${binary:Version})
+        libopx-nas-common-dev (>= 6.1.0),libopx-base-model-dev (>= 3.109.0),libopx-nas-linux1 (=${binary:Version})
 Description: This package contains the Linux integration portion of the Network abstractions service.
 
 Package: opx-nas-linux
 Architecture: any
-Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2), python-ipaddress (>= 1.0.17-1), python-enum34 (>= 1.1.6-1)
+Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2)
 Description: This package contains the Linux integration portion of the Network abstractions service.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: Copyright (c) 2018 Dell Inc.
+Copyright: Copyright (c) 2019 Dell Inc.
 License: Apache-2.0
 
 License: Apache-2.0

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,5 +15,4 @@
 #
 
 #All exported headers
-nobase_include_HEADERS= opx/cps_api_interface_types.h  opx/db_linux_event_register.h  opx/ds_api_linux_route.h  opx/nas_os_l3.h opx/net_publish.h opx/cps_api_route.h opx/ds_api_linux_interface.h opx/nas_linux_l2.h opx/nas_os_lag.h opx/db_api_linux_init.h  opx/ds_api_linux_neigh.h opx/nas_os_interface.h opx/nas_os_vlan.h opx/nas_os_mcast_snoop.h opx/nas_os_vxlan.h opx/private/nas_os_l3_utils.h opx/private/os_interface_cache_utils.h
-
+nobase_include_HEADERS=opx/cps_api_interface_types.h opx/db_linux_event_register.h opx/ds_api_linux_route.h opx/nas_os_l3.h opx/net_publish.h opx/cps_api_route.h opx/ds_api_linux_interface.h opx/nas_linux_l2.h opx/nas_os_lag.h opx/db_api_linux_init.h opx/ds_api_linux_neigh.h opx/nas_os_interface.h opx/nas_os_vlan.h opx/nas_os_mcast_snoop.h opx/nas_os_vxlan.h opx/nas_os_lpbk.h

--- a/inc/opx/cps_api_interface_types.h
+++ b/inc/opx/cps_api_interface_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/cps_api_route.h
+++ b/inc/opx/cps_api_route.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/db_api_linux_init.h
+++ b/inc/opx/db_api_linux_init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/db_linux_event_register.h
+++ b/inc/opx/db_linux_event_register.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/ds_api_linux_interface.h
+++ b/inc/opx/ds_api_linux_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -45,7 +45,7 @@ t_std_error ds_api_linux_interface_init(cps_api_operation_handle_t handle);
  */
 
 bool nl_get_if_info(int rt_msg_type, struct nlmsghdr *hdr, cps_api_object_t obj, void *context);
-bool nl_get_ip_info(int rt_msg_type, struct nlmsghdr *hdr, cps_api_object_t obj, void *context, uint32_t vrf_id);
+bool nl_get_ip_info(int rt_msg_type, struct nlmsghdr *hdr, cps_api_object_t obj, void *context, uint32_t vrf_id,  cps_api_qualifier_t qual);
 bool nl_get_ip_netconf_info(int rt_msg_type, struct nlmsghdr *hdr, cps_api_object_t obj, void *context, uint32_t vrf_id);
 
 bool nl_interface_get_request(int sock, int req_id, char *vrf_name, uint32_t vrf_id);

--- a/inc/opx/ds_api_linux_neigh.h
+++ b/inc/opx/ds_api_linux_neigh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/ds_api_linux_route.h
+++ b/inc/opx/ds_api_linux_route.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -55,6 +55,8 @@ bool nl_netconf_get_all_request(int sock, int family,int req_id);
  *
  */
 t_std_error nas_os_flush_ip_neigh(char *prefix, uint32_t prefix_len, bool is_intf_flush, char *dev);
+
+t_std_error ds_api_linux_ip_init(cps_api_operation_handle_t handle);
 #ifdef __cplusplus
 }
 #endif

--- a/inc/opx/nas_linux_l2.h
+++ b/inc/opx/nas_linux_l2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_os_interface.h
+++ b/inc/opx/nas_os_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_os_l3.h
+++ b/inc/opx/nas_os_l3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -109,6 +109,15 @@ t_std_error nas_os_refresh_neighbor (cps_api_object_t obj);
  * @return STD_ERR_OK if successful, otherwise different error code
  */
 t_std_error nas_os_resolve_neighbor (cps_api_object_t obj);
+
+/**
+ * @brief This sets the neighbor entry state in kernel
+ *
+ * @param obj CPS API object which contains arp/nd params
+ *
+ * @return STD_ERR_OK if successful, otherwise different error code
+ */
+t_std_error nas_os_set_neighbor_state (cps_api_object_t obj);
 
 /**
  * @brief : This creates the VRF in the kernel

--- a/inc/opx/nas_os_lag.h
+++ b/inc/opx/nas_os_lag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_os_lpbk.h
+++ b/inc/opx/nas_os_lpbk.h
@@ -14,25 +14,40 @@
  * permissions and limitations under the License.
  */
 
-/*!
- * \file  os_interface_mgmt.cpp 
+/*
+ * filename: nas_os_lpbk.h
  */
+#ifndef NAS_OS_LPBK_H_
+#define NAS_OS_LPBK_H_
 
-#include "private/nas_os_if_priv.h"
-#include "dell-base-common.h"
 #include "cps_api_object.h"
+#include "std_error_codes.h"
 
-#include <string.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#define MGMT_INTF_NAME      "eth0"
+/**
+ * @brief : Deletes a loopback interface
+ *
+ * @obj : CPS API object for delete operation
+ *
+ * @return : Returns cps_api_ret_code_OK on success, or error code
+ */
+t_std_error nas_os_lpbk_delete(cps_api_object_t obj);
 
-bool INTERFACE::os_interface_mgmt_attrs_handler(if_details *details, cps_api_object_t obj)
-{
+/**
+ * @brief : Creates a loopback interface
+ *
+ * @obj : CPS API object for create operation
+ *
+ * @return : Returns cps_api_ret_code_OK on success, or error code
+ */
+t_std_error nas_os_lpbk_create(cps_api_object_t obj);
 
-    if ((details->if_name.c_str() != nullptr)
-            && (strcmp(details->if_name.c_str(), MGMT_INTF_NAME) == 0)) {
-        details->_type = BASE_CMN_INTERFACE_TYPE_MANAGEMENT;
-    }
 
-    return true;
+#ifdef __cplusplus
 }
+#endif
+
+#endif /* NAS_OS_LPBK_H_ */

--- a/inc/opx/nas_os_mcast_snoop.h
+++ b/inc/opx/nas_os_mcast_snoop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_os_vlan.h
+++ b/inc/opx/nas_os_vlan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -37,13 +37,16 @@ extern "C" {
  * @obj : CPS API object which contains bridge_name to create
  *
  * @br_index : Returns the bridge index on response during create
+ * # TO Be Replaced by nas_os_create_bridge API
  */
 t_std_error nas_os_add_vlan(cps_api_object_t obj, hal_ifindex_t *br_index);
 
+t_std_error nas_os_create_bridge(cps_api_object_t obj, hal_ifindex_t *br_index);
 /**
  * @brief : Del Vlan : This removes the bridge interface from kernel
  *
  * @obj : CPS API object which contains bridge_name and kernel ifindex
+ * # TO Be Replaced by nas_os_delete_bridge API
  */
 
 t_std_error nas_os_del_vlan(cps_api_object_t obj);
@@ -155,6 +158,18 @@ t_std_error nas_os_vlan_set_member_port_mtu(cps_api_object_t obj);
  * @return STD_ERR_OK if successful otherwise different error code
  */
 t_std_error nas_os_change_master(hal_ifindex_t slave_ifindex,hal_vlan_id_t vlan_id ,hal_ifindex_t master_ifindex);
+
+/*
+ * @brief : Update enable or disable ipv6 on the  interface in the  OS
+ *
+ * @intf_name - interface  name
+ *
+ * @enable  : set to true to enable and false to disable.
+ *
+ * @return: true if successful
+ */
+
+bool nas_os_interface_ipv6_config_handle (const char *intf_name, bool enable);
 
 #ifdef __cplusplus
 }

--- a/inc/opx/nas_os_vxlan.h
+++ b/inc/opx/nas_os_vxlan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/net_publish.h
+++ b/inc/opx/net_publish.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/nas_nlmsg.h
+++ b/inc/opx/private/nas_nlmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/nas_nlmsg_object_utils.h
+++ b/inc/opx/private/nas_nlmsg_object_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/nas_os_if_priv.h
+++ b/inc/opx/private/nas_os_if_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -139,6 +139,8 @@ public:
     void if_info_delete(hal_ifindex_t ifx, std::string &name);
     bool if_info_get(hal_ifindex_t ifx, if_info_t& if_info);
     bool if_info_get_admin(hal_ifindex_t ifx, bool& admin);
+    hal_ifindex_t if_info_get_master(hal_ifindex_t ifx);
+
     bool get_ifindex_from_name(std::string &if_name, hal_ifindex_t &if_index);
     void for_each_mbr(std::function <void (int ix, if_info_t& if_info)> fn);
 };

--- a/inc/opx/private/nas_os_int_utils.h
+++ b/inc/opx/private/nas_os_int_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -78,6 +78,8 @@ t_std_error nas_os_util_int_mtu_get(const char *name, unsigned int *mtu);
 
 t_std_error nas_os_util_int_get_if(cps_api_object_t obj, hal_ifindex_t ifix);
 
+t_std_error os_intf_type_get(hal_ifindex_t ifix, BASE_CMN_INTERFACE_TYPE_t *if_type);
+
 t_std_error nas_os_util_int_flags_get(const char *vrf_name, const char *name, unsigned *flags);
 
 t_std_error nas_os_util_int_get_if_details(const char *name, cps_api_object_t obj);
@@ -90,6 +92,9 @@ t_std_error os_intf_mac_addr_get(hal_ifindex_t ifix, hal_mac_addr_t mac);
 
 t_std_error nas_os_util_int_if_index_get(const char *vrf_name, const char *if_name, int *if_index);
 
+
+t_std_error os_intf_master_get(hal_ifindex_t ifix, hal_ifindex_t *master_idx);
+
 t_std_error nas_os_util_int_if_name_get(const char *vrf_name, int if_index, char *if_name);
 
 t_std_error nas_os_util_int_oper_status_get (const char *vrf_name, const char *name,
@@ -99,6 +104,7 @@ t_std_error nas_os_util_int_ethtool_cmd_data_get (const char *vrf_name, const ch
 
 t_std_error nas_os_util_int_ethtool_cmd_data_set (const char *vrf_name, const char *name, ethtool_cmd_data_t *eth_cmd);
 t_std_error nas_os_util_int_stats_get (const char *vrf_name, const char *name, os_int_stats_t *stats);
+bool nas_os_interface_ipv6_config_handle (const char *intf_name, bool enable);
 #ifdef __cplusplus
 }
 #endif

--- a/inc/opx/private/nas_os_l3_utils.h
+++ b/inc/opx/private/nas_os_l3_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -30,15 +30,27 @@ typedef enum _nas_rt_msg_type {
     NAS_RT_DEL,
     NAS_RT_SET,
     NAS_RT_REFRESH,
-    NAS_RT_RESOLVE
+    NAS_RT_RESOLVE,
+    NAS_RT_SET_STATE
 }nas_rt_msg_type;
 
 t_std_error nas_os_update_vrf(cps_api_object_t obj, nas_rt_msg_type m_type);
 t_std_error nas_os_handle_intf_to_mgmt_vrf(cps_api_object_t obj, nas_rt_msg_type m_type);
 t_std_error nas_os_handle_intf_to_vrf(cps_api_object_t obj, nas_rt_msg_type m_type);
+bool nas_os_get_vrf_id(const char *vrf_name, uint32_t *p_vrf_id);
 const char* nas_os_get_vrf_name(uint32_t vrf_id);
 t_std_error nas_remove_intf_to_vrf_binding(uint32_t if_index);
 bool nas_rt_is_reserved_intf_idx (unsigned int if_idx, bool sub_intf_check_required);
+
+typedef struct nas_os_ip_info_s {
+   uint32_t ip_family;
+   uint32_t if_index;
+   uint32_t vrf_id;
+   bool     filter_if_index;
+   cps_api_get_params_t *param;
+} nas_os_ip_info_t;
+
+t_std_error os_ip_addr_object_reg(cps_api_operation_handle_t handle);
 #ifdef __cplusplus
 }
 #endif

--- a/inc/opx/private/nas_os_vlan_utils.h
+++ b/inc/opx/private/nas_os_vlan_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/netlink_stats.h
+++ b/inc/opx/private/netlink_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/netlink_tools.h
+++ b/inc/opx/private/netlink_tools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -45,8 +45,8 @@ extern "C" {
  * that we don't expect and would have undesirable consequences
  */
 
-/* Netlink socket buffer size for interface events - 30MB */
-#define NL_INTF_SOCKET_BUFFER_LEN (30*1024*1024)
+/* Netlink socket buffer size for interface events - 60MB */
+#define NL_INTF_SOCKET_BUFFER_LEN (60*1024*1024)
 
 /* Netlink socket buffer size for neighbor events - 150MB */
 #define NL_NEIGH_SOCKET_BUFFER_LEN (150*1024*1024)

--- a/inc/opx/private/os_if_utils.h
+++ b/inc/opx/private/os_if_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/os_interface_cache_utils.h
+++ b/inc/opx/private/os_interface_cache_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/standard_netlink_requests.h
+++ b/inc/opx/private/standard_netlink_requests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/scripts/bin/base_mcast_snoop.py
+++ b/scripts/bin/base_mcast_snoop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/init/opx-ip.service
+++ b/scripts/init/opx-ip.service
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/init/opx-mcast-snoop.service
+++ b/scripts/init/opx-mcast-snoop.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Multicast Snooping Configuration Service
+After=opx-cps.service
+Wants=opx-cps.service
+OnFailure=service_onfailure@%n.service
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/opx/opx-environment
+ExecStart=/usr/bin/python -u /usr/bin/base_mcast_snoop.py
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/init/opx-vrf.service
+++ b/scripts/init/opx-vrf.service
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_br_tool.py
+++ b/scripts/lib/python/dn_base_br_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_id_tool.py
+++ b/scripts/lib/python/dn_base_id_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_ip_tbl_tool.py
+++ b/scripts/lib/python/dn_base_ip_tbl_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_ipsec_utils.py
+++ b/scripts/lib/python/dn_base_ipsec_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_mcast_snoop_events.py
+++ b/scripts/lib/python/dn_base_mcast_snoop_events.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/dn_base_mcast_snoop_utils.py
+++ b/scripts/lib/python/dn_base_mcast_snoop_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/ifindex_utils.py
+++ b/scripts/lib/python/ifindex_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/db_linux_interface.c
+++ b/src/db_linux_interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/ds_interface_name_tools.c
+++ b/src/ds_interface_name_tools.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/ds_linux_init.c
+++ b/src/ds_linux_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_bridge.cpp
+++ b/src/if/os_interface_bridge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_cache.cpp
+++ b/src/if/os_interface_cache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -127,6 +127,19 @@ BASE_CMN_INTERFACE_TYPE_t INTERFACE::if_info_get_type(hal_ifindex_t ifx)
     return (it->second.if_type);
 }
 
+hal_ifindex_t INTERFACE::if_info_get_master(hal_ifindex_t ifx)
+{
+    std_rw_lock_read_guard lg(&rw_lock);
+
+    auto it = if_map_.find(ifx);
+
+    if(it == if_map_.end()) {
+        EV_LOGGING(NAS_OS, DEBUG, "NAS-OS-CACHE", "interface not present in the map %d", ifx);
+        return BASE_CMN_INTERFACE_TYPE_NULL;
+    }
+
+    return (it->second.master_idx);
+}
 bool INTERFACE::if_info_get_admin(hal_ifindex_t ifx, bool& admin)
 {
     std_rw_lock_read_guard lg(&rw_lock);
@@ -192,7 +205,7 @@ bool INTERFACE::get_ifindex_from_name(std::string &if_name, hal_ifindex_t &if_in
 
     auto it = name_ifindex_map_.find(if_name);
     if (it == name_ifindex_map_.end()) {
-        EV_LOGGING(NAS_OS, ERR, "NAS-OS-CACHE","couldn't find ifindex in name cache %d", if_index);
+        EV_LOGGING(NAS_OS, INFO, "NAS-OS-CACHE","couldn't find ifindex in name cache %d", if_index);
         return false;
     } else {
         if_index = it->second;

--- a/src/if/os_interface_cache_utils.cpp
+++ b/src/if/os_interface_cache_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_lag.cpp
+++ b/src/if/os_interface_lag.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_loopback.cpp
+++ b/src/if/os_interface_loopback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_macvlan.cpp
+++ b/src/if/os_interface_macvlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_stg.cpp
+++ b/src/if/os_interface_stg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/if/os_interface_vlan.cpp
+++ b/src/if/os_interface_vlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_os_int_utils.c
+++ b/src/nas_os_int_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_os_ip.cpp
+++ b/src/nas_os_ip.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -36,9 +36,12 @@
 #include "nas_vrf_utils.h"
 #include "std_system.h"
 #include "hal_if_mapping.h"
+#include "std_utils.h"
+#include "std_time_tools.h"
 
 #include <map>
 #include <sstream>
+#include <unordered_set>
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -46,9 +49,82 @@
 #include <stdlib.h>
 #include <linux/netconf.h>
 
+#include <arpa/inet.h>
+#include <linux/netlink.h>
+#include <sys/socket.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
 /* This provides the global IP forwarding status */
 static bool is_global_ipv4_fwd_enable = true;
 static bool is_global_ipv6_fwd_enable = true;
+
+/* Store the IP address to detect and ignore the duplicate IP events from OS. */
+typedef struct ip_addr_key_t_ {
+    uint32_t vrf_id;
+    uint32_t if_index;
+    std::string ip_addr;
+    bool operator== (const ip_addr_key_t_& key) const
+    {
+        if ((vrf_id == key.vrf_id) &&
+            (if_index == key.if_index) &&
+            (ip_addr == key.ip_addr)) {
+            return true;
+        }
+        return false;
+    }
+}ip_addr_key_t;
+
+typedef struct ip_addr_key_hash_t_ {
+    std::size_t operator() (ip_addr_key_t const& key) const
+    {
+        std::size_t vrf_hash = std::hash<std::string>() (std::to_string(key.vrf_id));
+        std::size_t if_index_hash = std::hash<std::string>() (std::to_string(key.if_index));
+        std::size_t ip_hash = std::hash<std::string>() (key.ip_addr);
+        return (vrf_hash ^ if_index_hash ^ ip_hash);
+    }
+}ip_addr_key_hash_t;
+
+/* This map is used to store the IP address */
+using nas_os_ip_addr_map_t = std::unordered_set<ip_addr_key_t, ip_addr_key_hash_t>;
+static nas_os_ip_addr_map_t nas_os_ip_addr_map;
+
+std::string nas_os_ip_addr_string (const hal_ip_addr_t& ip)
+{
+    char buff[INET6_ADDRSTRLEN + 1];
+    return(std_ip_to_string(&ip, buff, INET6_ADDRSTRLEN));
+}
+
+/* Store the IP address and check if there is any duplicate IP, if yes, return dup flag */
+static void nas_os_handle_dynamic_ipv6_addr(uint32_t vrf_id, bool is_del, uint32_t if_index,
+                                            hal_ip_addr_t &ip_addr, bool &is_dup)
+{
+    ip_addr_key_t key;
+
+    key.vrf_id = vrf_id;
+    key.if_index = if_index;
+    key.ip_addr = nas_os_ip_addr_string(ip_addr);
+
+    auto ip_addr_itr = nas_os_ip_addr_map.find(key);
+
+    if (ip_addr_itr == nas_os_ip_addr_map.end()) {
+        if (is_del == false) {
+            EV_LOGGING(NETLINK,DEBUG,"NAS-IP","IP added in the list");
+            nas_os_ip_addr_map.emplace(key);
+        } else {
+            EV_LOGGING(NETLINK,DEBUG,"NAS-IP","IP not preset in the list");
+        }
+    } else {
+        if (is_del) {
+            EV_LOGGING(NETLINK,DEBUG,"NAS-IP","IP deleted from the list");
+            nas_os_ip_addr_map.erase(ip_addr_itr);
+        } else {
+            EV_LOGGING(NETLINK,DEBUG,"NAS-IP","Duplicate IP detected!");
+            is_dup = true;
+        }
+    }
+}
 
 bool nas_os_is_reserved_ipv4(hal_ip_addr_t *p_ip_addr)
 {
@@ -107,42 +183,50 @@ extern "C" t_std_error nas_os_read_ipv6_status(const char *vrf_name, char *name,
     return rc;
 }
 
+typedef enum { IP_KEY, IFINDEX, PREFIX, ADDRESS, IFNAME, VRFNAME, DAD_FAILED, ENABLED, AUTOCONF_ADDR, VRFID} attr_t ;
+static const std::map<uint32_t, std::map<int,cps_api_attr_id_t>> _ipmap = {
+    {AF_INET,
+        {
+            {IP_KEY,  BASE_IP_IPV4_OBJ},
+            {IFINDEX, BASE_IP_IPV4_IFINDEX},
+            {PREFIX,  BASE_IP_IPV4_ADDRESS_PREFIX_LENGTH},
+            {ADDRESS, BASE_IP_IPV4_ADDRESS_IP},
+            {IFNAME,  BASE_IP_IPV4_NAME},
+            {VRFNAME, BASE_IP_IPV4_VRF_NAME},
+            {VRFID, BASE_IP_IPV4_VRF_ID}
+        }},
+
+    {AF_INET6,
+        {
+            {IP_KEY,  BASE_IP_IPV6_OBJ},
+            {IFINDEX, BASE_IP_IPV6_IFINDEX},
+            {PREFIX,  BASE_IP_IPV6_ADDRESS_PREFIX_LENGTH},
+            {ADDRESS, BASE_IP_IPV6_ADDRESS_IP},
+            {IFNAME,  BASE_IP_IPV6_NAME},
+            {VRFNAME, BASE_IP_IPV6_VRF_NAME},
+            {DAD_FAILED, BASE_IP_IPV6_DAD_FAILED},
+            {ENABLED, BASE_IP_IPV6_ENABLED},
+            {AUTOCONF_ADDR, BASE_IP_IPV6_ADDRESS_AUTOCONF_ADDR},
+            {VRFID, BASE_IP_IPV6_VRF_ID},
+        }}
+};
+
 extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_object_t obj,
-                                void *context, uint32_t vrf_id) {
+                                void *context, uint32_t vrf_id, cps_api_qualifier_t qual) {
 
     struct ifaddrmsg *ifmsg = (struct ifaddrmsg *)NLMSG_DATA(hdr);
 
     if(hdr->nlmsg_len < NLMSG_LENGTH(sizeof(*ifmsg)))
         return false;
 
-    typedef enum { IP_KEY, IFINDEX, PREFIX, ADDRESS, IFNAME, VRFNAME, DAD_FAILED, ENABLED, AUTOCONF_ADDR} attr_t ;
-    static const std::map<uint32_t, std::map<int,cps_api_attr_id_t>> _ipmap = {
-      {AF_INET,
-      {
-        {IP_KEY,  BASE_IP_IPV4_OBJ},
-        {IFINDEX, BASE_IP_IPV4_IFINDEX},
-        {PREFIX,  BASE_IP_IPV4_ADDRESS_PREFIX_LENGTH},
-        {ADDRESS, BASE_IP_IPV4_ADDRESS_IP},
-        {IFNAME,  BASE_IP_IPV4_NAME},
-        {VRFNAME, BASE_IP_IPV4_VRF_NAME}
-      }},
-
-      {AF_INET6,
-      {
-        {IP_KEY,  BASE_IP_IPV6_OBJ},
-        {IFINDEX, BASE_IP_IPV6_IFINDEX},
-        {PREFIX,  BASE_IP_IPV6_ADDRESS_PREFIX_LENGTH},
-        {ADDRESS, BASE_IP_IPV6_ADDRESS_IP},
-        {IFNAME,  BASE_IP_IPV6_NAME},
-        {VRFNAME, BASE_IP_IPV6_VRF_NAME},
-        {DAD_FAILED, BASE_IP_IPV6_DAD_FAILED},
-        {ENABLED, BASE_IP_IPV6_ENABLED},
-        {AUTOCONF_ADDR, BASE_IP_IPV6_ADDRESS_AUTOCONF_ADDR},
-      }}
-    };
+    /* Ignore the IP events for other than IPv4 and Ipv6 families. */
+    if ((ifmsg->ifa_family != AF_INET) && (ifmsg->ifa_family != AF_INET6)) {
+        EV_LOGGING(NETLINK,INFO,"NAS-IP","IP events recd for the family:%d", ifmsg->ifa_family);
+        return false;
+    }
 
     cps_api_key_from_attr_with_qual(cps_api_object_key(obj),_ipmap.at(ifmsg->ifa_family).at(IP_KEY),
-                                    cps_api_qualifier_OBSERVED);
+                                    qual);
 
     cps_api_set_key_data(obj,_ipmap.at(ifmsg->ifa_family).at(IFINDEX), cps_api_object_ATTR_T_U32,
                          &ifmsg->ifa_index,sizeof(ifmsg->ifa_index));
@@ -172,6 +256,7 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
     }
     cps_api_object_attr_add(obj, _ipmap.at(ifmsg->ifa_family).at(VRFNAME), vrf_name,
                             strlen(vrf_name)+1);
+    cps_api_object_attr_add_u32(obj, _ipmap.at(ifmsg->ifa_family).at(VRFID), vrf_id);
     cps_api_object_attr_add_u32(obj, _ipmap.at(ifmsg->ifa_family).at(IFINDEX), ifmsg->ifa_index);
     cps_api_object_attr_add_u32(obj, _ipmap.at(ifmsg->ifa_family).at(PREFIX), ifmsg->ifa_prefixlen);
 
@@ -182,12 +267,12 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
     memset(attrs,0,sizeof(attrs));
 
     if (nla_parse(attrs,__IFLA_MAX,head,nla_len)!=0) {
-        EV_LOG_TRACE(ev_log_t_NAS_OS,ev_log_s_WARNING,"IP-NL-PARSE","Failed to parse attributes");
+        EV_LOGGING(NETLINK,ERR,"IP-NL-PARSE","Failed to parse attributes");
         return false;
     }
     char            addr_str[INET6_ADDRSTRLEN];
     char            local_addr_str[INET6_ADDRSTRLEN];
-    EV_LOGGING(NAS_OS,INFO,"NAS-OS-IP", "Operation:%s(%d) VRF:%s(%d) flags:0x%x if-index:%s(%d) IP:%s/%d if-flags:0x%x scope:%d local:%s",
+    EV_LOGGING(NETLINK,INFO,"NAS-OS-IP", "Operation:%s(%d) VRF:%s(%d) flags:0x%x if-index:%s(%d) IP:%s/%d if-flags:0x%x scope:%d local:%s",
                ((rt_msg_type == RTM_NEWADDR) ? "Add" : ((rt_msg_type == RTM_DELADDR) ? "Del" : "Set")),
                rt_msg_type, vrf_name, vrf_id,
                (attrs[IFA_FLAGS] ? *(int *)nla_data((struct nlattr*)attrs[IFA_FLAGS]) :0),
@@ -210,23 +295,23 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
                             ((struct in6_addr *) nla_data((struct nlattr*)attrs[IFA_LOCAL])),
                             local_addr_str, INET6_ADDRSTRLEN))) : "NA"));
 
+    hal_ip_addr_t ip;
+    memset(&ip, 0, sizeof(ip));
     if (attrs[IFA_ADDRESS]!=NULL) {
         size_t addr_len = (ifmsg->ifa_family == AF_INET)?HAL_INET4_LEN:HAL_INET6_LEN;
-        hal_ip_addr_t ip;
-        memset(&ip, 0, sizeof(ip));
         ip.af_index = ifmsg->ifa_family;
         if (ifmsg->ifa_family == AF_INET) {
             struct in_addr *inp = (struct in_addr *) nla_data((struct nlattr*)attrs[IFA_ADDRESS]);
             std_ip_from_inet(&ip,inp);
             if (nas_os_is_reserved_ipv4(&ip)) {
-                EV_LOGGING(NETLINK,ERR,"ROUTE-EVT","IPv4 address ignored - if-index:%d", ifmsg->ifa_index);
+                EV_LOGGING(NETLINK,DEBUG,"ROUTE-EVT","IPv4 address ignored - if-index:%d", ifmsg->ifa_index);
                 return false;
             }
         } else if (ifmsg->ifa_family == AF_INET6) {
             struct in6_addr *inp6 = (struct in6_addr *) nla_data((struct nlattr*)attrs[IFA_ADDRESS]);
             std_ip_from_inet6(&ip,inp6);
             if (nas_os_is_reserved_ipv6(&ip)) {
-                EV_LOGGING(NETLINK,ERR,"ROUTE-EVT","IPv6 address ignored - if-index:%d", ifmsg->ifa_index);
+                EV_LOGGING(NETLINK,DEBUG,"ROUTE-EVT","IPv6 address ignored - if-index:%d", ifmsg->ifa_index);
                 return false;
             }
         }
@@ -248,10 +333,20 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
         }
         /* Set the flag if the IPv6 address is created dynamically. */
         if (ifa_flags & IFA_F_MANAGETEMPADDR) {
+            /* Duplicate the dynamic ipv6 address publish */
+            bool is_dup = false, is_del = (rt_msg_type == RTM_DELADDR) ? true : false;
+            if ((ip.af_index == AF_INET6) &&
+                (is_del || ((ifa_flags & IFA_F_DADFAILED) != IFA_F_DADFAILED))) {
+                nas_os_handle_dynamic_ipv6_addr(vrf_id, is_del, ifmsg->ifa_index, ip, is_dup);
+                if (is_dup) {
+                    return false;
+                }
+            }
             cps_api_object_attr_add_u32(obj, _ipmap.at(ifmsg->ifa_family).at(AUTOCONF_ADDR),
                                         true);
         }
     }
+
     if (rt_msg_type == RTM_NEWADDR)  {
         cps_api_object_set_type_operation(cps_api_object_key(obj),cps_api_oper_CREATE);
     } else if (rt_msg_type == RTM_DELADDR)  {
@@ -263,7 +358,7 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
     if (ifmsg->ifa_family == AF_INET6) {
         char intf_name[HAL_IF_NAME_SZ+1];
         if (nas_os_util_int_if_name_get(vrf_name, ifmsg->ifa_index, intf_name) != STD_ERR_OK) {
-            EV_LOGGING(NAS_OS, ERR, "IP-PUB",
+            EV_LOGGING(NETLINK, ERR, "IP-PUB",
                        "Interface %d to if_name from OS returned error",
                        ifmsg->ifa_index);
             if (rt_msg_type == RTM_DELADDR)  {
@@ -291,7 +386,7 @@ extern "C" bool nl_get_ip_info (int rt_msg_type, struct nlmsghdr *hdr, cps_api_o
                 cps_api_object_attr_add_u32(obj, _ipmap.at(ifmsg->ifa_family).at(ENABLED),
                                             ipv6_enabled);
             } else {
-                EV_LOGGING(NAS_OS,ERR,"NAS-IP","IPv6 status read for the vrf-name:%s intf:%s failed!",
+                EV_LOGGING(NETLINK,ERR,"NAS-IP","IPv6 status read for the vrf-name:%s intf:%s failed!",
                            vrf_name, intf_name);
             }
         }
@@ -305,6 +400,11 @@ extern "C" bool nl_get_ip_netconf_info (int rt_msg_type, struct nlmsghdr *hdr, c
                                         uint32_t vrf_id) {
     struct rtattr   *rtatp = NULL;
     struct netconfmsg *ncmsg = (struct netconfmsg*)NLMSG_DATA(hdr);
+
+    /* Ignore the netconf events for other than IPv4 and Ipv6 families. */
+    if ((ncmsg->ncm_family != AF_INET) && (ncmsg->ncm_family != AF_INET6))
+        return false;
+
     typedef enum { IP_KEY, IFINDEX, FWD, VRFNAME } attr_t ;
     static const std::map<uint32_t, std::map<int,cps_api_attr_id_t>> _ipmap = {
         {AF_INET,
@@ -421,3 +521,405 @@ bool nl_netconf_get_all_request(int sock, int family,int req_id) {
                            req_id,&ncm,sizeof(ncm));
 }
 
+#define NL_MSG_BUFFER_LEN 9000
+
+static cps_api_return_code_t nas_os_ip_key_info_get(uint32_t family, cps_api_object_t obj,
+                          char *vrf_name, uint8_t vrf_name_len, char *if_name, uint8_t if_name_len, uint32_t *if_index)
+{
+    cps_api_object_attr_t if_name_attr = cps_api_get_key_data(obj, _ipmap.at(family).at(IFNAME));
+    cps_api_object_attr_t if_index_attr = cps_api_object_attr_get(obj, _ipmap.at(family).at(IFINDEX));
+    cps_api_object_attr_t vrf_attr = cps_api_object_attr_get(obj, _ipmap.at(family).at(VRFNAME));
+
+    if ((if_name_attr == NULL) && (if_index_attr == NULL)) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS","No If_name or if-index attr");
+        return cps_api_ret_code_ERR;
+    }
+
+    if (vrf_attr != NULL)
+        safestrncpy(vrf_name, (const char *)cps_api_object_attr_data_bin(vrf_attr), vrf_name_len);
+    else
+        safestrncpy(vrf_name, NAS_DEFAULT_VRF_NAME, vrf_name_len);
+
+    interface_ctrl_t intf_ctrl;
+    t_std_error rc = STD_ERR_OK;
+
+    if (if_name_attr != NULL) {
+        safestrncpy(if_name, (const char *)cps_api_object_attr_data_bin(if_name_attr), if_name_len);
+
+        if ((if_index_attr == NULL) || (vrf_attr == NULL)) {
+            memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+            intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+            safestrncpy(intf_ctrl.if_name, if_name, sizeof(intf_ctrl.if_name));
+            if((rc= dn_hal_get_interface_info(&intf_ctrl)) != STD_ERR_OK) {
+                EV_LOGGING(NAS_OS, ERR, "IFADDRESS",
+                           "Interface %s to if_index returned error %d", intf_ctrl.if_name, rc);
+                return cps_api_ret_code_ERR;
+            }
+
+            *if_index = intf_ctrl.if_index;
+
+            if (vrf_attr == NULL) {
+                if (NAS_DEFAULT_VRF_ID != intf_ctrl.vrf_id)
+                   return cps_api_ret_code_ERR;
+
+            }
+        }
+    } else if (if_index_attr != NULL) {
+        *if_index = cps_api_object_attr_data_u32(if_index_attr);
+        if (vrf_attr == NULL) {
+            memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+            intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF;
+            intf_ctrl.if_index = *if_index;
+
+            if ((dn_hal_get_interface_info(&intf_ctrl)) != STD_ERR_OK) {
+                EV_LOGGING(NAS_OS, ERR, "IFADDRESS",
+                                  "Failed in retrieving intf from cache, "
+                                  "if_index:%d", *if_index);
+                return cps_api_ret_code_ERR;
+            }
+
+            safestrncpy(if_name, intf_ctrl.if_name, if_name_len);
+
+            if (vrf_attr == NULL) {
+                if (NAS_DEFAULT_VRF_ID != intf_ctrl.vrf_id)
+                    return cps_api_ret_code_ERR;
+            }
+        }
+    }
+
+    return cps_api_ret_code_OK;
+}
+
+static bool nas_os_ip_get_broadcast_ip(char *addr, uint32_t prefix_len, char *broadcast_addr)
+{
+   uint32_t mask = 0;
+   uint32_t bcast_addr = 0;
+
+   /* Broadcast domain is not there for /31 and /32 prefix length */
+   if (prefix_len >= (HAL_INET4_LEN * 8) - 1){
+       return false;
+   }
+
+   mask = ((prefix_len) ? ((1 << ((8 * sizeof(uint32_t) - prefix_len))) -1) : 0xffffffff);
+   memcpy((char *)&bcast_addr, addr, HAL_INET4_LEN);
+
+   char *ip = (char *)&bcast_addr;
+   bcast_addr = (uint32_t)(ip[0] << 24 | ip[1] << 16 | ip[2] << 8 | ip[3])  |  mask;
+
+   for (int i = 0; i < HAL_INET4_LEN ; i++)
+       memcpy(&broadcast_addr[i], (char *)&ip[3-i], 1);
+
+   return true;
+}
+
+static cps_api_return_code_t nas_os_ip_addr_write_function(cps_api_operation_types_t op, uint32_t family,
+                                                         void *context, cps_api_object_t obj)
+{
+    char      vrf_name[NAS_VRF_NAME_SZ] = {0};
+    char      if_name[HAL_IF_NAME_SZ] = {0};
+    char      addr_str[INET6_ADDRSTRLEN];
+    char      bcast_addr_str[INET6_ADDRSTRLEN];
+    uint32_t  if_index = 0;
+    char      bcast_addr[HAL_INET4_LEN] = {0};
+
+    if (nas_os_ip_key_info_get (family, obj, vrf_name, sizeof(vrf_name),
+        if_name, sizeof(if_name), &if_index) != cps_api_ret_code_OK) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Failed in retrieving base-ip key ");
+        return cps_api_ret_code_ERR;
+    }
+
+    cps_api_object_attr_t pre_len_attr = cps_api_object_attr_get(obj, _ipmap.at(family).at(PREFIX));
+    cps_api_object_attr_t ip_attr  = cps_api_get_key_data(obj, _ipmap.at(family).at(ADDRESS));
+    if (ip_attr == NULL)
+        return cps_api_ret_code_ERR;
+
+    if (pre_len_attr == NULL)
+       return cps_api_ret_code_ERR;
+
+    uint32_t prefix_len =  cps_api_object_attr_data_uint(pre_len_attr);
+    char  *buff = (char *)malloc(NL_MSG_BUFFER_LEN);
+
+    if (NULL == buff)
+       return cps_api_ret_code_ERR;
+
+    memset(buff, 0, NL_MSG_BUFFER_LEN);
+
+    struct nlmsghdr *nlh = (struct nlmsghdr *) nlmsg_reserve((struct nlmsghdr *)buff, NL_MSG_BUFFER_LEN, sizeof(struct nlmsghdr));
+    struct ifaddrmsg *ifaddr = (struct ifaddrmsg *) nlmsg_reserve(nlh, NL_MSG_BUFFER_LEN, sizeof(struct ifaddrmsg));
+
+    //sizeof structure + attrs nlh->nlmsg_len
+    nlh->nlmsg_pid = 0;
+    nlh->nlmsg_seq = 0;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK ;
+    nlh->nlmsg_type = RTM_NEWADDR;
+
+    if (op==cps_api_oper_CREATE) {
+        nlh->nlmsg_flags |= NLM_F_CREATE | NLM_F_EXCL | NLM_F_APPEND;
+    }
+    if (op==cps_api_oper_SET) {
+        nlh->nlmsg_flags |=NLM_F_REPLACE;
+    }
+    if (op==cps_api_oper_DELETE) {
+        nlh->nlmsg_type = RTM_DELADDR;
+    }
+
+    ifaddr->ifa_family = family;
+    ifaddr->ifa_prefixlen = prefix_len;
+    ifaddr->ifa_flags = IFA_F_PERMANENT;
+    ifaddr->ifa_index = if_index;
+    ifaddr->ifa_scope = 0;
+
+    nlmsg_add_attr(nlh, NL_MSG_BUFFER_LEN, IFA_LOCAL, cps_api_object_attr_data_bin(ip_attr), cps_api_object_attr_len(ip_attr));
+
+    if (family == AF_INET) {
+        nas_os_ip_get_broadcast_ip((char *)cps_api_object_attr_data_bin(ip_attr), prefix_len, &bcast_addr[0]);
+        nlmsg_add_attr(nlh, NL_MSG_BUFFER_LEN, IFA_BROADCAST, &bcast_addr[0], cps_api_object_attr_len(ip_attr));
+    }
+
+    EV_LOGGING(NAS_OS, INFO, "IFADDRESS", "IP ADDRESS %s family:%s if_name:%s "
+               "vrf %s ip %s bcast_ip %s prefix len %d ",
+               (op == cps_api_oper_CREATE ? "ADD" : (op == cps_api_oper_DELETE ? "DEL" : "SET")),
+               (family == AF_INET ? "IPv4" : "IPv6"), if_name, vrf_name,
+               ((family == AF_INET) ? (inet_ntop(family, cps_api_object_attr_data_bin(ip_attr), addr_str, INET_ADDRSTRLEN)) :
+                (inet_ntop(family, cps_api_object_attr_data_bin(ip_attr), addr_str, INET6_ADDRSTRLEN))),
+               ((family == AF_INET) ? (inet_ntop(family, &bcast_addr[0], bcast_addr_str, INET_ADDRSTRLEN)) : ("na")),
+               prefix_len);
+
+    if (nl_do_set_request(vrf_name, nas_nl_sock_T_ROUTE, nlh, buff, NL_MSG_BUFFER_LEN) != STD_ERR_OK) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Failed to set ip address on interface %s", if_name);
+        free(buff);
+        return cps_api_ret_code_ERR;
+    }
+    free(buff);
+    return cps_api_ret_code_OK;
+}
+
+extern "C" bool nl_get_nas_os_ip_info (int sock, int rt_msg_type, struct nlmsghdr *hdr, void *context,
+                                       uint32_t vrf_id) {
+    struct ifaddrmsg *ifmsg = (struct ifaddrmsg *)NLMSG_DATA(hdr);
+    nas_os_ip_info_t *p_ip_info = (nas_os_ip_info_t *)context;
+
+    if(hdr->nlmsg_len < NLMSG_LENGTH(sizeof(*ifmsg))) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS","hdr->nlmsg_len:%d", hdr->nlmsg_len);
+        return false;
+    }
+
+    /* Ignore the IP events for other than IPv4 and Ipv6 families. */
+    if ((ifmsg->ifa_family != AF_INET) && (ifmsg->ifa_family != AF_INET6)) {
+        EV_LOGGING(NAS_OS, ERR,"IFADDRESS","IP events recd for the family:%d", ifmsg->ifa_family);
+        return false;
+    }
+
+    EV_LOGGING(NAS_OS, INFO,"IFADDRESS","Get ip keys, family:(in: %d)%d if_index (in: %d)%d vrf_id %d",
+               p_ip_info->ip_family, ifmsg->ifa_family,
+               p_ip_info->if_index, ifmsg->ifa_index, vrf_id);
+
+    /* Ignore the IP events for other than IPv4 and Ipv6 families. */
+    if ((ifmsg->ifa_family != p_ip_info->ip_family) ||
+        ((p_ip_info->filter_if_index == true) && (ifmsg->ifa_index != p_ip_info->if_index))) {
+        EV_LOGGING(NAS_OS, INFO, "IFADDRESS","Skip. Keys not matched family:(in: %d)%d if_index (in: %d)%d vrf_id %d",
+                   p_ip_info->ip_family, ifmsg->ifa_family, p_ip_info->if_index, ifmsg->ifa_index, vrf_id);
+        return true;
+    }
+
+    cps_api_object_t obj = cps_api_object_create();
+    if (obj == NULL) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS","Failed to create object");
+        return false;
+    }
+
+    if (nl_get_ip_info (rt_msg_type, hdr, obj, NULL, vrf_id, cps_api_qualifier_TARGET)) {
+        if(cps_api_object_list_append(p_ip_info->param->list, obj) != true) {
+            EV_LOGGING(NAS_OS, ERR, "IFADDRESS","Failed to appened object list");
+            cps_api_object_delete(obj);
+            return false;
+        }
+    } else {
+      cps_api_object_delete(obj);
+    }
+
+    return true;
+}
+
+/* Read supported
+ * - With out any keys - Will return all interfces ip address in all vrf's/
+ * - if_name/If_idex with out VRF attribute - VRF is considered as default
+ * - if_name/If_dex with non default VRF - VRF attribute is mandatory to get/set ip address
+ */
+cps_api_return_code_t nas_os_ip_addr_read_function (uint32_t ip_family, void *context,
+                                                 cps_api_get_params_t *param,
+                                                 size_t ix)
+{
+    cps_api_object_t in_obj = cps_api_object_list_get(param->filters,ix);
+
+    if (in_obj == NULL)
+        return cps_api_ret_code_ERR;
+
+    char     vrf_name[NAS_VRF_NAME_SZ] = {0};
+    char     if_name[HAL_IF_NAME_SZ] = {0};
+    uint32_t if_index = 0;
+    int      sock = 0;
+    nas_os_ip_info_t ip_info = {0};
+    cps_api_return_code_t ret = cps_api_ret_code_ERR;
+
+    cps_api_object_attr_t vrf_attr = cps_api_object_attr_get(in_obj, _ipmap.at(ip_family).at(VRFNAME));
+    cps_api_object_attr_t if_name_attr = cps_api_get_key_data(in_obj, _ipmap.at(ip_family).at(IFNAME));
+    cps_api_object_attr_t if_index_attr = cps_api_object_attr_get(in_obj, _ipmap.at(ip_family).at(IFINDEX));
+
+
+    if (((if_name_attr != NULL) || (if_index_attr != NULL)) &&
+        (nas_os_ip_key_info_get (ip_family, in_obj, vrf_name, sizeof(vrf_name), if_name,
+         sizeof(if_name), &if_index) != cps_api_ret_code_OK)) {
+        EV_LOGGING(NAS_OS, ERR,"IFADDRESS", "BASE IP key not found, Read all interface ip's");
+        return cps_api_ret_code_ERR;
+    }
+
+    EV_LOGGING(NAS_OS, INFO, "IFADDRESS", "GET IP ADDRESS family:%s if_name:%s vrf_name %s ",
+                      (ip_family == AF_INET ? "IPv4" : "IPv6"), if_name, vrf_name);
+
+    uint32_t vrf_id = NAS_DEFAULT_VRF_ID;
+
+    char *buff = (char *)malloc(NL_MSG_BUFFER_LEN);
+
+    if (NULL == buff)
+        return cps_api_ret_code_ERR;
+
+    do {
+        if ((vrf_attr != NULL) || (if_name_attr != NULL) || (if_index_attr !=NULL)) {
+            if (nas_os_get_vrf_id(vrf_name, &vrf_id)) {
+                EV_LOGGING(NAS_OS, DEBUG, "IFADDRESS", "VRF-id get for VRF:%s VRF ID %d ",
+                           vrf_name, vrf_id);
+            } else {
+                EV_LOGGING(NAS_OS,ERR,"IFADDRESS", "VRF-id get failed for VRF:%s ", vrf_name);
+                ret = cps_api_ret_code_ERR;
+                break;
+            }
+        } else {
+            const char *name = nas_os_get_vrf_name(vrf_id);
+            if (name == NULL) {
+                vrf_id++;
+                ret = cps_api_ret_code_OK;
+                continue;
+            }
+            safestrncpy(vrf_name, name, sizeof(vrf_name));
+        }
+
+        do {
+            if((sock = nas_nl_sock_create(vrf_name, nas_nl_sock_T_ROUTE,false)) < 0) {
+                EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Socket create failure");
+                break;
+            }
+
+            memset(buff, 0, NL_MSG_BUFFER_LEN);
+
+            struct ifaddrmsg ifaddr;
+            memset(&ifaddr,0,sizeof(ifaddrmsg));
+
+            ifaddr.ifa_family = ip_family;
+            ifaddr.ifa_index = if_index;
+
+            ip_info.ip_family = ip_family;
+            ip_info.if_index = if_index;
+            /* TODO - Even after giving the filter NLM_F_MATCH  for family and interface index.
+             * net link returns for all interfcaes in family. Filter is done in software now.
+             * Revisit codein new linux version */
+            if ((if_name_attr != NULL) || (if_index_attr != NULL))
+                ip_info.filter_if_index = true;
+
+            ip_info.param = param;
+
+            int seq = (int)std_get_uptime(NULL);
+
+            if (nl_send_request(sock, RTM_GETADDR, (NLM_F_REQUEST | NLM_F_ACK | NLM_F_MATCH),
+                                seq, &ifaddr, sizeof(ifaddrmsg))) {
+                netlink_tools_process_socket(sock, nl_get_nas_os_ip_info,
+                                             (void *)&ip_info, buff, NL_MSG_BUFFER_LEN, &seq, NULL, vrf_id);
+            }
+            close(sock);
+        } while(0);
+
+        vrf_id++;
+
+        ret = cps_api_ret_code_OK;
+    } while(((if_name_attr == NULL) && (if_index_attr == NULL) && (vrf_attr == NULL) && (vrf_id <= NAS_MAX_VRF_ID)));
+
+    free(buff);
+
+    return ret;
+}
+
+static cps_api_return_code_t nas_os_ipv4_write_function(void * context,
+                             cps_api_transaction_params_t * param, size_t ix) {
+
+    cps_api_object_t obj = cps_api_object_list_get(param->change_list,ix);
+    if (obj == NULL)
+        return cps_api_ret_code_ERR;
+
+    cps_api_operation_types_t op = cps_api_object_type_operation(cps_api_object_key(obj));
+
+    return nas_os_ip_addr_write_function(op, AF_INET, context,obj);
+}
+
+static cps_api_return_code_t nas_os_ipv6_write_function(void * context,
+                             cps_api_transaction_params_t * param, size_t ix) {
+
+    cps_api_object_t obj = cps_api_object_list_get(param->change_list,ix);
+    if (obj==NULL)
+        return cps_api_ret_code_ERR;
+
+    cps_api_operation_types_t op = cps_api_object_type_operation(cps_api_object_key(obj));
+
+    return nas_os_ip_addr_write_function(op, AF_INET6, context,obj);
+}
+
+cps_api_return_code_t nas_os_ipv4_read_function (void * context,
+                                               cps_api_get_params_t *param,
+                                               size_t ix)
+{
+    return nas_os_ip_addr_read_function(AF_INET, context, param, ix);
+}
+
+cps_api_return_code_t nas_os_ipv6_read_function (void * context,
+                                               cps_api_get_params_t *param,
+                                               size_t ix)
+{
+    return nas_os_ip_addr_read_function(AF_INET6, context, param, ix);
+}
+
+t_std_error os_ip_addr_object_reg(cps_api_operation_handle_t handle) {
+
+    cps_api_registration_functions_t f;
+    cps_api_return_code_t cps_rc = 0;
+
+    memset(&f,0,sizeof(f));
+    f.handle = handle;
+    f._read_function = nas_os_ipv4_read_function;
+    f._write_function = nas_os_ipv4_write_function;
+
+    if (!cps_api_key_from_attr_with_qual(&f.key, BASE_IP_IPV4_ADDRESS, cps_api_qualifier_TARGET)) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Cannot create a key for BASE_IP_IPV4_ADDRESS object");
+        return STD_ERR(INTERFACE, FAIL, 0);
+    } else {
+        if ((cps_rc = cps_api_register(&f)) !=cps_api_ret_code_OK) {
+            EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Failed to register callback for BASE_IP_IPV4_ADDRESS object");
+            return STD_ERR(QOS, FAIL, cps_rc);
+        }
+    }
+
+    memset(&f,0,sizeof(f));
+    f.handle = handle;
+    f._read_function = nas_os_ipv6_read_function;
+    f._write_function = nas_os_ipv6_write_function;
+
+    if (!cps_api_key_from_attr_with_qual(&f.key, BASE_IP_IPV6_ADDRESS, cps_api_qualifier_TARGET)) {
+        EV_LOGGING(NAS_OS, ERR, "IFADDRESS", "Cannot create a key for BASE_IP_IPV6_ADDRESS object");
+        return STD_ERR(INTERFACE, FAIL, 0);
+    } else {
+        if ((cps_rc = cps_api_register(&f)) !=cps_api_ret_code_OK) {
+            EV_LOGGING(NETLINK, ERR, "IFADDRESS", "Failed to register callback for BASE_IP_IPV6_ADDRESS object");
+            return STD_ERR(QOS, FAIL, cps_rc);
+        }
+    }
+
+    return STD_ERR_OK;
+}

--- a/src/nas_os_lag.c
+++ b/src/nas_os_lag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -104,6 +104,13 @@ static t_std_error nas_add_del_dummy_to_lag(hal_ifindex_t if_index, bool add) {
             EV_LOGGING(NAS_OS, ERR, "NAS-OS-LAG",
                    "Error dummy interface %s creation failed in the Kernel", bond_dummy_name);
             return (STD_ERR(NAS_OS, FAIL, 0));
+        }
+
+        /*
+         * Disable ipv6 on LAG dummy interface.
+         */
+        if (nas_os_interface_ipv6_config_handle(bond_dummy_name, false) == false) {
+            EV_LOGGING(NAS_OS, ERR, "NAS-OS-LAG", "Failed: To disable ipv6 on sub interface (%s)", bond_dummy_name);
         }
     }
     hal_ifindex_t ifix = cps_api_interface_name_to_if_index(bond_dummy_name);

--- a/src/nas_os_lpbk.cpp
+++ b/src/nas_os_lpbk.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_os_lpbk.c
+ *
+ *  Created on: January 16, 2019
+ */
+#include "dell-base-if.h"
+#include "ds_api_linux_interface.h"
+#include "ds_common_types.h"
+#include "event_log.h"
+#include "nas_nlmsg.h"
+#include "nas_os_interface.h"
+#include "nas_os_lpbk.h"
+#include <net/if.h>
+#include "netlink_tools.h"
+#include "std_mac_utils.h"
+#include <string.h>
+
+#define NL_MSG_BUFF 4096
+#define NULL_BYTE   1
+
+
+t_std_error nas_os_lpbk_create(cps_api_object_t obj)
+{
+    char *lpbk_name = NULL;
+    cps_api_object_attr_t attr;
+
+    char buff[NL_MSG_BUFF];
+    hal_ifindex_t if_index = 0;
+    const char *info_kind = "dummy";
+    unsigned int flags = (IFF_BROADCAST | IFF_NOARP);
+
+    memset(buff, 0, NL_MSG_BUFF);
+
+    struct nlmsghdr *nlh = (struct nlmsghdr *) nlmsg_reserve((struct nlmsghdr *)buff, sizeof(buff), sizeof(struct nlmsghdr));
+    struct ifinfomsg *ifmsg = (struct ifinfomsg *) nlmsg_reserve(nlh, sizeof(buff), sizeof(struct ifinfomsg));
+
+    flags &= ~IFF_UP;
+
+    nas_os_pack_nl_hdr(nlh, RTM_NEWLINK, (NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL));
+    nas_os_pack_if_hdr(ifmsg, AF_PACKET, flags, if_index);
+
+    attr = cps_api_object_attr_get(obj, IF_INTERFACES_INTERFACE_NAME);
+    if (attr == CPS_API_ATTR_NULL) {
+        EV_LOGGING(NAS_OS, ERR, "NAS-OS-LPBK", "Missing loopback name for adding to kernel");
+        return (STD_ERR(NAS_OS, FAIL, 0));
+    } else {
+        lpbk_name = (char*)cps_api_object_attr_data_bin(attr);
+        nlmsg_add_attr(nlh,sizeof(buff),IFLA_IFNAME, lpbk_name , strlen(lpbk_name)+1);
+        EV_LOGGING(NAS_OS, DEBUG, "NAS-OS-LPBK", "loopback name is %s", lpbk_name);
+    }
+
+    attr = cps_api_object_attr_get(obj, DELL_IF_IF_INTERFACES_INTERFACE_MTU);
+    if (attr != CPS_API_ATTR_NULL) {
+        unsigned int mtu = 0;
+        mtu = cps_api_object_attr_data_u32(attr);
+        nlmsg_add_attr(nlh, sizeof(buff), IFLA_MTU, &mtu , sizeof(mtu));
+        EV_LOGGING(NAS_OS, DEBUG, "NAS-OS-LPBK", "setting MTU (%d) in kernel", mtu);
+    }
+
+    attr = cps_api_object_attr_get(obj, DELL_IF_IF_INTERFACES_INTERFACE_PHYS_ADDRESS);
+    if (attr != CPS_API_ATTR_NULL) {
+        char *addr = NULL;
+        hal_mac_addr_t mac_addr;
+        addr = (char*)cps_api_object_attr_data_bin(attr);
+        if (std_string_to_mac(&mac_addr, (const char *)addr, sizeof(mac_addr))) {
+            nlmsg_add_attr(nlh, sizeof(buff), IFLA_ADDRESS, &mac_addr , sizeof(hal_mac_addr_t));
+            EV_LOGGING(NAS_OS, DEBUG, "NAS-OS-LPBK", "setting MAC address (%s) in kernel", (const char *)mac_addr);
+        }
+    }
+
+    nlmsg_add_attr(nlh, sizeof(buff), IFLA_IFNAME, lpbk_name, (strlen(lpbk_name) + NULL_BYTE));
+
+    struct nlattr *attr_nh = nlmsg_nested_start(nlh, sizeof(buff));
+    attr_nh->nla_len = 0;
+    attr_nh->nla_type = IFLA_LINKINFO;
+    nlmsg_add_attr(nlh, sizeof(buff), IFLA_INFO_KIND, info_kind, (strlen(info_kind) + NULL_BYTE));
+    nlmsg_nested_end(nlh, attr_nh);
+
+    if(nl_do_set_request(NL_DEFAULT_VRF_NAME, nas_nl_sock_T_INT, nlh, buff, sizeof(buff)) != STD_ERR_OK) {
+        EV_LOGGING(NAS_OS, ERR, "NAS-OS-LPBK", "Failure creating loopback (%s) in kernel", lpbk_name);
+        return (STD_ERR(NAS_OS, FAIL, 0));
+    } else {
+        /* add interface index */
+        hal_ifindex_t ifix = cps_api_interface_name_to_if_index(lpbk_name);
+        cps_api_object_attr_add_u32(obj, DELL_BASE_IF_CMN_IF_INTERFACES_INTERFACE_IF_INDEX, ifix);
+    }
+
+    return STD_ERR_OK;
+}
+
+t_std_error nas_os_lpbk_delete(cps_api_object_t obj)
+{
+    cps_api_object_attr_t attr;
+    hal_ifindex_t         if_index = 0;
+    char                 *lpbk_name = NULL;
+
+    attr = cps_api_object_attr_get(obj, IF_INTERFACES_INTERFACE_NAME);
+    if (attr == CPS_API_ATTR_NULL) {
+        EV_LOGGING(NAS_OS, ERR, "NAS-OS-LPBK", "Missing loopback name for delete  request");
+        return cps_api_ret_code_ERR;
+    } else {
+        lpbk_name = (char*)cps_api_object_attr_data_bin(attr);
+    }
+
+    if_index = cps_api_interface_name_to_if_index(lpbk_name);
+    if (nas_os_del_interface(if_index) != STD_ERR_OK){
+        EV_LOGGING(NAS_OS, ERR, "NAS-OS-LPBK", "Failure deleting loopback (%s) from kernel", lpbk_name);
+        return cps_api_ret_code_ERR;
+    }
+
+    cps_api_object_attr_add_u32(obj, DELL_BASE_IF_CMN_IF_INTERFACES_INTERFACE_IF_INDEX, if_index);
+    return cps_api_ret_code_OK;
+}
+

--- a/src/nas_os_mcast_snoop.cpp
+++ b/src/nas_os_mcast_snoop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -69,18 +69,17 @@ static bool _populate_mdb_entry_object(struct br_mdb_entry *br_entry, int msg_ty
     std::string _addr_proto;
     char *grp_addr = nullptr;
     size_t grp_addr_len = 0;
+    char ip6_grp_addr[INET6_ADDRSTRLEN];
     if (ntohs(br_entry->addr.proto) == ETH_P_IP) {
         struct in_addr ip_addr;
         ip_addr.s_addr = br_entry->addr.u.ip4;
 
         grp_addr = inet_ntoa(ip_addr);
-        grp_addr_len = strlen(grp_addr);
+        grp_addr_len = strlen(grp_addr)+1;
         _addr_proto = "ipv4";
     }
     else if (ntohs(br_entry->addr.proto) == ETH_P_IPV6) {
-        char ip6_grp_addr[INET6_ADDRSTRLEN];
         inet_ntop(AF_INET6, &(br_entry->addr.u.ip6), ip6_grp_addr, INET6_ADDRSTRLEN);
-
         grp_addr = ip6_grp_addr;
         grp_addr_len = INET6_ADDRSTRLEN;
         _addr_proto = "ipv6";
@@ -108,7 +107,7 @@ static bool _populate_mdb_entry_object(struct br_mdb_entry *br_entry, int msg_ty
 
     ids[2] = (*_cps_keymap)[_addr_proto]["grp_addr"];
 
-    cps_api_object_e_add(obj, ids, ids_len, cps_api_object_ATTR_T_BIN, grp_addr, grp_addr_len+1);
+    cps_api_object_e_add(obj, ids, ids_len, cps_api_object_ATTR_T_BIN, grp_addr, grp_addr_len);
     EV_LOGGING(NETLINK_MCAST_SNOOP,DEBUG,"NAS-LINUX-MCAST-SNOOP", "Group address %s ", grp_addr);
 
     // INFO log with all information

--- a/src/nas_os_stg.cpp
+++ b/src/nas_os_stg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_os_vlan_utils.c
+++ b/src/nas_os_vlan_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -43,11 +43,11 @@ void nas_os_get_vlan_if_name(char *if_name, int len, hal_vlan_id_t vlan_id, char
 bool nas_os_physical_to_vlan_ifindex(hal_ifindex_t intf_index, hal_vlan_id_t vlan_id,
                                             bool to_vlan,hal_ifindex_t * index){
     char intf_name[HAL_IF_NAME_SZ+1];
-    char vlan_intf_name[HAL_IF_NAME_SZ+1];
+    char vlan_intf_name[HAL_IF_NAME_SZ*2+1];
     char *converted_intf_name = NULL;
 
     if(cps_api_interface_if_index_to_name(intf_index,intf_name,sizeof(intf_name))==NULL){
-        EV_LOG(ERR,NAS_OS,0,"NAS-LINUX-INTERFACE","Invalid Interface Index %d ",intf_index);
+        EV_LOG(INFO,NAS_OS,0,"NAS-LINUX-INTERFACE","Invalid Interface Index %d ",intf_index);
         return false;
     }
 

--- a/src/netlink_stats.cpp
+++ b/src/netlink_stats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/netlink_tools.c
+++ b/src/netlink_tools.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/cps_api_interface_unittest.c
+++ b/src/unit_test/cps_api_interface_unittest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/cps_api_route_unittest.cpp
+++ b/src/unit_test/cps_api_route_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/db_unit_test.cpp
+++ b/src/unit_test/db_unit_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/ds_api_linux_neigh_unittest.cpp
+++ b/src/unit_test/ds_api_linux_neigh_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -84,11 +84,15 @@ bool test_get_all_neigh(void) {
         size_t mx = cps_api_object_list_size(gp.list);
         for ( ; ix < mx ; ++ix ) {
             cps_api_object_t obj = cps_api_object_list_get(gp.list,ix);
-            cps_api_object_attr_t mac = cps_api_object_attr_get(obj,cps_api_if_NEIGH_A_NBR_MAC);
-            hal_mac_addr_t m;
-            memcpy(m,cps_api_object_attr_data_bin(mac),sizeof(m));
-            char buff[50];
-            printf("Neigh: %s\n",std_mac_to_string(&m,buff,sizeof(buff)));
+            if (obj != NULL) {
+                cps_api_object_attr_t mac = cps_api_object_attr_get(obj,cps_api_if_NEIGH_A_NBR_MAC);
+                if (mac != NULL) {
+                    hal_mac_addr_t m;
+                    memcpy(m,cps_api_object_attr_data_bin(mac),sizeof(m));
+                    char buff[50];
+                    printf("Neigh: %s\n",std_mac_to_string(&m,buff,sizeof(buff)));
+                }
+            }
         }
         rc = true;
     }

--- a/src/unit_test/ds_api_linux_route_unittest.cpp
+++ b/src/unit_test/ds_api_linux_route_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_linux_stg_unittest.cpp
+++ b/src/unit_test/nas_linux_stg_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_mcast_snoop_svc_unittest.cpp
+++ b/src/unit_test/nas_mcast_snoop_svc_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <gtest/gtest.h>
 
+#include "std_utils.h"
 #include "cps_class_map.h"
 #include "cps_api_operation.h"
 #include "cps_api_object_key.h"
@@ -104,12 +105,12 @@ static bool mc_event_handler(cps_api_object_t evt_obj, void *param)
         cps_api_attr_id_t attr_id = cps_api_object_attr_id(it.attr);
         if (attr_id == mrouter_id) {
             if (event_type == 1) {
-                strncpy(received_igmp_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
+                safestrncpy(received_igmp_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
                         sizeof(received_igmp_mrouter_ifname));
                 std::cout<<"Handling mrouter event VLAN: "<<received_vlan<<
                          " mrouter interface: "<<received_igmp_mrouter_ifname<<std::endl;
             } else if (event_type == 2) {
-                strncpy(received_mld_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
+                safestrncpy(received_mld_mrouter_ifname, (const char *)cps_api_object_attr_data_bin(it.attr),
                         sizeof(received_mld_mrouter_ifname));
                 std::cout<<"Handling mrouter event VLAN: "<<received_vlan<<
                          " mrouter interface: "<<received_mld_mrouter_ifname<<std::endl;

--- a/src/unit_test/nas_os_l3_unittest.cpp
+++ b/src/unit_test/nas_os_l3_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -304,11 +304,15 @@ static cps_api_return_code_t nas_ut_validate_nas_rt_cfg (const char *ip_addr, ui
     return rc;
 }
 
-static cps_api_return_code_t nas_rt_lnx_ip_addr_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, const char *dev)
+static cps_api_return_code_t nas_rt_lnx_ip_addr_cfg (bool is_add,
+                                                     const char *ip_addr,
+                                                     uint32_t prefix_len,
+                                                     const char *dev)
 {
     char cmd_str[300];
-    snprintf (cmd_str, 300, "ip address %s %s/%d  dev %s", (is_add ? "add":"del"), ip_addr, prefix_len, dev);
-    if (system(cmd_str));
+    snprintf (cmd_str, 300, "ip address %s %s/%d  dev %s",
+              (is_add ? "add":"del"), ip_addr, prefix_len, dev);
+    system(cmd_str);
     return cps_api_ret_code_OK;
 }
 
@@ -317,7 +321,7 @@ static cps_api_return_code_t nas_rt_lnx_intf_admin_cfg (bool is_up, const char *
     char cmd_str[300];
 
     snprintf (cmd_str, 300, "ip link set dev %s %s", dev, (is_up)?"up":"down");
-    if(system(cmd_str));
+    (void)system(cmd_str);
     /* wait for few seconds after making admin up */
     if (is_up)
         sleep (5);
@@ -330,28 +334,28 @@ static cps_api_return_code_t nas_rt_lnx_vlan_intf_cfg (bool is_add, const char* 
     if (is_add)
     {
         snprintf (cmd_str, 300, "ip link set dev %s up", vlan_mem_port);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "brctl addbr %s", vlan_intf);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "ip link add link %s name %s.%d type vlan id %d", vlan_mem_port, vlan_mem_port, vlan_id, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "brctl addif %s %s.%d", vlan_intf, vlan_mem_port, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "ip link set dev %s.%d up", vlan_mem_port, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
     }
     else
     {
         snprintf (cmd_str, 300, "ip link set dev %s.%d down", vlan_mem_port, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "brctl delif %s %s.%d", vlan_intf, vlan_mem_port, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "ip link set dev %s down", vlan_mem_port);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "ip link del dev %s.%d ", vlan_mem_port, vlan_id);
-        if(system(cmd_str));
+        (void)system(cmd_str);
         snprintf (cmd_str, 300, "brctl delbr %s", vlan_intf);
-        if(system(cmd_str));
+        (void)system(cmd_str);
     }
     return cps_api_ret_code_OK;
 }
@@ -498,8 +502,8 @@ TEST(std_route_test, del_neighbor) {
 TEST(std_route_test, add_ip_and_check_self_ip_pub) {
     char cmd_str[200];
 
-    if(system("opx-logging enable NETLINK info"));
-    if(system("kill -USR1 `pidof base_nas`"));
+    (void)system("os10-logging enable NETLINK info");
+    (void)system("kill -USR1 `pidof base_nas`");
 
     memset(cmd_str, 0, sizeof(cmd_str));
     system("ip addr add 8.1.1.2/24 dev e101-008-0");
@@ -539,8 +543,8 @@ TEST(std_route_test, add_ip_and_check_self_ip_pub) {
     ASSERT_TRUE (ret == 0);
     */
 
-    if(system("opx-logging disable NETLINK info"));
-    if(system("kill -USR1 `pidof base_nas`"));
+    (void)system("os10-logging disable NETLINK info");
+    (void)system("kill -USR1 `pidof base_nas`");
 }
 
 
@@ -1130,12 +1134,12 @@ TEST(std_nas_route_test, nas_os_verify_lla) {
         ret = system("ip -6 route show | grep -c fe80 > /tmp/result");
         FILE * result = fopen("/tmp/result","r");
         int val = 0;
-        fscanf(result, "%d", &val);
+        (void) fscanf(result, "%d", &val);
         fclose(result);
 
         printf("\r\n LLA count:%d\r\n", val);
-        ASSERT_TRUE(val >=150);
         fclose(fp);
+        ASSERT_TRUE(val >=150);
 
         fp = fopen("/tmp/test_pre_req","w");
         fprintf(fp, "configure terminal\n");
@@ -1192,13 +1196,13 @@ TEST(std_nas_route_test, nas_os_verify_proxy_arp) {
     nas_ut_proxy_arp_cfg("default", "br1", true);
     result = fopen("/proc/sys/net/ipv4/conf/br1/proxy_arp","r");
     ASSERT_TRUE(result != NULL);
-    fscanf(result, "%d", &val);
+    (void) fscanf(result, "%d", &val);
     fclose(result);
     ASSERT_TRUE(val == 1);
     nas_ut_proxy_arp_cfg("default", "br1", false);
     result = fopen("/proc/sys/net/ipv4/conf/br1/proxy_arp","r");
     ASSERT_TRUE(result != NULL);
-    fscanf(result, "%d", &val);
+    (void) fscanf(result, "%d", &val);
     fclose(result);
     ASSERT_TRUE(val == 0);
 }

--- a/src/unit_test/nas_os_mac_unittest.cpp
+++ b/src/unit_test/nas_os_mac_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_os_vlan_unittest.cpp
+++ b/src/unit_test/nas_os_vlan_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_vxlan_unittest.cpp
+++ b/src/unit_test/nas_vxlan_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -18,6 +18,7 @@
  * nas_vxlan_unittest.cpp
  *
  *  Created on: May 22, 2018
+ *      Author: vraiyani
  */
 
 

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/ip_addr_config_unittest.py
+++ b/src/unit_test/scripts/ip_addr_config_unittest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/ip_rule_test.py
+++ b/src/unit_test/scripts/ip_rule_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -160,7 +160,6 @@ def test_rule_obj():
     print 'IPv4 rule created:'
     print str(rule1)
     print str(rule2)
-    assert rule1 == rule1
     assert not rule1 == rule2
     assert rule1.match(src_ip = socket.inet_pton(af, '1.1.1.0'), src_prefix_len = 24)
     assert not rule2.match(src_ip = socket.inet_pton(af, '1.1.1.0'), src_prefix_len = 24)
@@ -170,7 +169,7 @@ def test_rule_obj():
                                 cfg.VrfSvcsRuleAction.RULE_ACTION_DNAT, af,
                                 src_ip = socket.inet_pton(af, '1::1'), src_prefix_len = 128,
                                 dst_ip = socket.inet_pton(af, '2::1'),
-                                protocol = cfg.VrfSvcsRuleProto.RULE_PROTO_ICMP)
+                                protocol = cfg.VrfSvcsRuleProto.RULE_PROTO_ICMPV6)
     rule2 = cfg.VrfIncomingSvcsRule(cfg.VrfSvcsRuleType.RULE_TYPE_IP, 'test_vrf',
                                 cfg.VrfSvcsRuleAction.RULE_ACTION_DNAT, af,
                                 src_ip = socket.inet_pton(af, '1::2'), src_prefix_len = 128,
@@ -179,7 +178,6 @@ def test_rule_obj():
     print 'IPv6 rule created:'
     print str(rule1)
     print str(rule2)
-    assert rule1 == rule1
     assert not rule1 == rule2
     assert rule1.match(src_ip = socket.inet_pton(af, '1::1'))
     assert not rule2.match(src_ip = socket.inet_pton(af, '1::1'))

--- a/src/unit_test/scripts/nas_incoming_svcs_ut.py
+++ b/src/unit_test/scripts/nas_incoming_svcs_ut.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -77,6 +77,8 @@ def parse_protocol(key, val):
         return 2
     elif val.lower() == 'icmp':
         return 3
+    elif val.lower() == 'icmpv6':
+        return 5
     else:
         return 4
 
@@ -161,7 +163,7 @@ parser.add_argument('-d', '--dst-ip', help = 'Destination IP address and mask')
 parser.add_argument('-f', '--addr-family', choices = ['ipv4', 'ipv6'], help = 'Address family')
 parser.add_argument('-i', '--seq-num', type = int, help = 'Sequence number')
 parser.add_argument('-a', '--action', choices = ['allow', 'deny'], help = 'Action')
-parser.add_argument('-p', '--protocol', choices = ['tcp', 'udp', 'icmp', 'all'], help = 'Protocol')
+parser.add_argument('-p', '--protocol', choices = ['tcp', 'udp', 'icmp', 'icmpv6', 'all'], help = 'Protocol')
 parser.add_argument('-dp', '--dst-port', type = int, help = 'L4 destination port')
 parser.add_argument('--multiport', help = 'L4 destination port range')
 parser.add_argument('-iif', '--in_intf', help = 'incoming interface')
@@ -367,6 +369,14 @@ def run_test_incoming_svcs():
         incoming_svcs_test(True,  "info", "-s", "10.11.8.12/32", "-f", "ipv4", "-p", "icmp", "-d", "10.11.70.22/32", "-iif", "eth0", "-a", "allow")
         incoming_svcs_test(True,  "info", "-n", "management", "-s", "10.11.8.12/32", "-f", "ipv4", "-p", "icmp", "-d", "10.11.70.22/32", "-iif", "eth0", "-a", "allow")
 
+        incoming_svcs_test(False,  "create", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(False,  "create", "-n", "management", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(False,  "info", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(False,  "info", "-n", "management", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(False,  "delete", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(False,  "delete", "-n", "management", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(True,  "info", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
+        incoming_svcs_test(True,  "info", "-n", "management", "-s", "1::/64", "-f", "ipv6", "-p", "icmpv6", "-d", "2::/64", "-iif", "eth0", "-a", "allow")
 
     except RuntimeError as ex:
         print 'UT failed: %s' % ex

--- a/src/unit_test/scripts/nas_os_intf_event_test.py
+++ b/src/unit_test/scripts/nas_os_intf_event_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_os_ip.py
+++ b/src/unit_test/scripts/nas_os_ip.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_os_ip.sh
+++ b/src/unit_test/scripts/nas_os_ip.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_outgoing_svcs_ut.py
+++ b/src/unit_test/scripts/nas_outgoing_svcs_ut.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_vxlan_test.py
+++ b/src/unit_test/scripts/nas_vxlan_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/run_test
+++ b/src/unit_test/scripts/run_test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/vrf_ip_svcs_rule_test.py
+++ b/src/unit_test/scripts/vrf_ip_svcs_rule_test.py
@@ -1,0 +1,528 @@
+import dn_base_vrf_svcs_config as cfg
+
+import subprocess
+import time
+
+orig_run_command = cfg.run_command
+
+def local_run_command(cmd, resp, log_fail = True):
+    global orig_run_command
+    if cmd[0] == '/sbin/iptables' or cmd[0] == '/sbin/ip6tables':
+      cmd = ['/sbin/ip', 'netns', 'exec', 'test_default'] + cmd
+    print 'RUN_CMD: %s' % ' '.join(cmd)
+    ret_val = orig_run_command(cmd, resp)
+    if log_fail and ret_val != 0:
+      print '*** Command execution failed ***'
+      print ' '.join(cmd)
+      for r in resp:
+        print r
+    return ret_val
+
+cfg.run_command = local_run_command
+
+def exec_shell(cmd):
+      proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+      (out, err) = proc.communicate()
+      return out
+
+""" configure the ip address for interface in default vrf
+"""
+def default_ip_address_pre_req_cfg(clear, intf_ip):
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+      mode = 'DoD'
+    if mode is 'DoD':
+      if clear:
+        cmd_list =  ['configure terminal',
+                     'interface ethernet 1/1/10',
+                     'no ip address',
+                     'switchport mode access',
+                     'exit',
+                     'end']
+      else:
+        cmd_list =  ['configure terminal',
+                     'interface ethernet 1/1/10',
+                     'no switchport',
+                     'ip address '+intf_ip,
+                     'exit',
+                     'end']
+  
+      cfg_file = open('/tmp/test_pre_req', 'w')
+      for item in cmd_list:
+        print>>cfg_file, item
+      cfg_file.close()
+      exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+      print 'UT for BASE is not supported yet.'
+
+
+""" configure the interface and vrf cli in mgmt / ethernet port for UT AR-22685
+"""
+def ip_address_pre_req_cfg(clear = False, mgmt_ip = '10.11.70.22/8',vrf='management'):
+#config test pre requisite - manangement vrf
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+      mode = 'DoD'
+    if mode is 'DoD':
+#configure the test pre requisites via CLI
+      if clear:
+        if vrf == 'management':
+          cmd_list =  ['configure terminal',
+                       'interface mgmt1/1/1',
+                       'no ip address',
+                       'exit',
+                       'ip vrf ' + vrf,
+                       'no interface management',
+                       'exit',
+                       'no ip vrf '+ vrf,
+                       'interface mgmt1/1/1',
+                       'ip address ' + mgmt_ip,
+                       'end']
+        else:
+          cmd_list =  ['configure terminal',
+                       'interface ethernet 1/1/1',
+                       'no ip address',
+                       'no ip vrf forwarding ',
+                       'switchport mode access',
+                       'exit',
+                       'no ip telnet server vrf '+ vrf,
+                       'yes',
+                       'no ip vrf '+vrf,
+                       'end']
+      else:
+        if vrf== 'management':
+          cmd_list =  ['configure terminal',
+                       'interface mgmt1/1/1',
+                       'no ip address',
+                       'no ipv6 address',
+                       'exit',
+                       'ip vrf '+vrf,
+                       'interface management',
+                       'exit',
+                       'interface mgmt1/1/1',
+                       'ip address ' + mgmt_ip,
+                       'end']
+        else:
+          cmd_list =  ['configure terminal',
+                       'ip vrf '+vrf,
+                       'exit',
+                       'interface ethernet 1/1/1',
+                       'no switchport',
+                       'ip vrf forwarding '+vrf,
+                       'ip address '+mgmt_ip,
+                       'exit',
+                       'end']
+
+      cfg_file = open('/tmp/test_pre_req', 'w')
+      for item in cmd_list:
+        print>>cfg_file, item
+      cfg_file.close()
+      exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+      print 'UT for BASE is not supported yet.'
+
+""" Configure ip service on non default vrf
+"""
+def ip_service_pre_req_cfg(vrf,ip_serv=0):
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+      mode = 'DoD'
+
+    if ip_serv:
+      cmd_list = ['configure terminal',
+                  'ip vrf '+vrf,
+                  'ip telnet server vrf '+ vrf,
+                  'yes']
+    else :
+      cmd_list = ['configure terminal',
+                  'no ip telnet server vrf '+ vrf,
+                  'yes',
+                  'interface ethernet 1/1/1',
+                  'no ip address',
+                  'no ip vrf forwarding ',
+                  'switchport mode access',
+                  'exit',
+                  'no ip vrf ' + vrf,]
+    if mode is 'DoD':
+      cfg_file = open('/tmp/test_pre_req', 'w')
+      for item in cmd_list:
+        print>>cfg_file, item
+      cfg_file.close()
+      exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+      print 'UT for BASE is not supported yet.'
+
+""" dump the iptable for prerouting chain and verify it has source ip or not
+"""
+def verify_ip_table_has_rule(vrf_name,ip_addr):
+    success = 0
+    resp = []
+    if vrf_name != 'default':
+      if orig_run_command(['/sbin/ip', 'netns','exec', vrf_name,'iptables','-t','nat','-L','PREROUTING'], resp) == 0:
+        print resp
+        for line in resp:
+          print line
+          if 'VRF' in line:
+            column = line.split('anywhere')
+            dest_ip = column[1].split('             ')
+            print dest_ip
+            if dest_ip[1] == ip_addr:
+              print 'Test is successful dest_ip %s' % dest_ip
+              success = 1
+              return success
+            else:
+              print 'skip %s' % line
+              success = 0
+    else:
+      if orig_run_command(['iptables','-t','nat','-L','PREROUTING'], resp) == 0:
+        print resp
+        for line in resp:
+          print line
+          if ip_addr in resp:
+            success=0
+            return success
+          else:
+            success =1
+
+    return success
+
+""" dump the ip6table for prerouting chain and verify it has source ip or not
+"""
+def verify_ip6_table_has_rule(vrf_name,ip_addr):
+    success = 0
+    resp = []
+    if vrf_name != 'default':
+      if orig_run_command(['/sbin/ip', 'netns','exec', vrf_name,'ip6tables','-t','nat','-L','PREROUTING'], resp) == 0:
+        print resp
+        for line in resp:
+          print line
+          if 'VRF' in line:
+            column = line.split('anywhere')
+            dest_ip = column[1].split('             ')
+            print dest_ip
+            if dest_ip[1] == ip_addr:
+              print 'Test is successful dest_ip %s' % dest_ip
+              success = 1
+              return success
+            else:
+              print 'skip %s' % line
+              success = 0
+    else:
+      if orig_run_command(['ip6tables','-t','nat','-L','PREROUTING'], resp) == 0:
+        print resp
+        for line in resp:
+          print line
+          if ip_addr in resp:
+            success=0
+            return success
+          else:
+            success =1
+
+    return success
+
+""" configure the interface and vrf cli in mgmt / ethernet port for UT AR-22685
+"""
+def ip_address_multiple_interface_pre_req_cfg(clear = False, mgmt_ip = '10.11.70.22/8',vrf='management'):
+#config test pre requisite - manangement vrf
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+      mode = 'DoD'
+    if mode is 'DoD':
+#configure the test pre requisites via CLI
+      if clear:
+        if vrf == 'management':
+          cmd_list =  ['configure terminal',
+                       'interface mgmt1/1/1',
+                       'no ip address',
+                       'exit',
+                       'ip vrf ' + vrf,
+                       'no interface management',
+                       'exit',
+                       'no ip vrf '+ vrf,
+                       'interface mgmt1/1/1',
+                       'ip address ' + mgmt_ip,
+                       'end']
+        else:
+          cmd_list =  ['configure terminal',
+                       'interface range ethernet 1/1/1-1/1/3',
+                       'no ip address',
+                       'no ip vrf forwarding ',
+                       'switchport mode access',
+                       'exit',
+                       'no ip telnet server vrf '+ vrf,
+                       'yes',
+                       'no ip vrf '+vrf,
+                       'end']
+      else:
+        if vrf== 'management':
+          cmd_list =  ['configure terminal',
+                       'interface mgmt1/1/1',
+                       'no ip address',
+                       'no ipv6 address',
+                       'exit',
+                       'ip vrf '+vrf,
+                       'interface management',
+                       'exit',
+                       'interface mgmt1/1/1',
+                       'ip address ' + mgmt_ip,
+                       'end']
+        else:
+          cmd_list =  ['configure terminal',
+                       'ip vrf '+vrf,
+                       'exit',
+                       'interface range ethernet 1/1/1-1/1/3',
+                       'no switchport',
+                       'ip vrf forwarding '+vrf,
+                       'exit',
+                       'interface ethernet 1/1/1',
+                       'ip address 1.1.1.1/24',
+                       'interface ethernet 1/1/2',
+                       'ip address 2.1.1.1/24',
+                       'interface ethernet 1/1/3',
+                       'ip address 3.1.1.1/24',
+                       'exit',
+                       'ip telnet server vrf '+ vrf,
+                       'yes',
+                       'end']
+      cfg_file = open('/tmp/test_pre_req', 'w')
+      for item in cmd_list:
+        print>>cfg_file, item
+      cfg_file.close()
+      exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+      print 'UT for BASE is not supported yet.'
+
+def ip_address_multiple_interface_remove_ip_cfg():
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+      mode = 'DoD'
+    if mode is 'DoD':
+      cmd_list =  ['configure terminal',
+                   'interface range ethernet 1/1/1-1/1/3',
+                   'no ip address',
+                   'end']
+      cfg_file = open('/tmp/test_pre_req', 'w')
+      for item in cmd_list:
+        print>>cfg_file, item
+      cfg_file.close()
+      exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+      print 'UT for BASE is not supported yet.'
+
+""" Validate the iptable rule for mangement and non default vrf
+"""
+def test_ip_table_rule_for_non_default_vrf():
+    resp = []
+
+    print '$$$$$$$$$$$$$$$$ TEST-1. IP service for management vrf  $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '################# Make sure no mangement vrf is available in the Linux shell ############'
+    print '#########################################################################################'
+    if orig_run_command(['/sbin/ip', 'netns','exec', 'management','iptables','-t','nat','-L','PREROUTING'], resp) != 0:
+      print resp
+      if 'Cannot' in resp[0]:
+        print '@@@@@@@@@@@@@@ : Unit test is PASSED. no vrf created yet @@@@@@@@@@@@@@'
+      else:
+        print '@@@@@@@@@@@@@@ : Unit test is FAILED. vrf is configured @@@@@@@@@@@@@@'
+    
+    print '#########################################################################################'
+    print '####Make sure mangement vrf is available in the Linux shell and src ip configured#######'
+    print '#########################################################################################'
+    ip_address_pre_req_cfg(False,'10.11.8.100/16','management')
+    time.sleep(20)
+    success = verify_ip_table_has_rule('management','10.11.8.100')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are avaiable for MGMT VRF @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for MGMT VRF @@@@@@@@@@@@@@'
+
+    success = verify_ip6_table_has_rule('management','fe80::/10')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Ip6table rules are avaiable for MGMT VRF fe80::/10 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for MGMT VRF fe80::/10 @@@@@@@@@@@@@@'
+
+    ip_address_pre_req_cfg(True,'10.11.8.100/16','management')
+    time.sleep(20)
+
+#Make sure no mangement vrf is available in the Linux shell
+    if orig_run_command(['/sbin/ip', 'netns','exec', 'management','iptables','-t','nat','-L','PREROUTING'], resp) != 0:
+      print resp
+      if 'Cannot' in resp[0]:
+        print '@@@@@@@@@@@@@@ Unit test is PASSED. vrf and iptable rules deleted @@@@@@@@@@@@@@'
+      else:
+        print '@@@@@@@@@@@@@@ Unit test is FAILED. vrf and iptable rules are not deleted @@@@@@@@@@@@@@'
+
+#Make sure no test_vrf is available in the Linux shell
+
+    print '$$$$$$$$$$$$$$$$ TEST-2. Validate ip table rule without ip service config $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '#######################Make sure no test_vrf is available in the Linux shell#############'
+    print '#########################################################################################'
+
+    if orig_run_command(['/sbin/ip', 'netns','exec', 'test_vrf','iptables','-t','nat','-L','PREROUTING'], resp) != 0:
+      print resp
+      if 'Cannot' in resp[0]:
+        print '@@@@@@@@@@@@@@ Unit test is PASSED. no vrf created yet @@@@@@@@@@@@@@'
+      else:
+        print '@@@@@@@@@@@@@@ Unit test is FAILED. vrf is configured @@@@@@@@@@@@@@'
+
+    print '#########################################################################################'
+    print '####Make sure test_vrf  is available but it shouldnt have ip table rule #################'
+    print '#########################################################################################'
+
+    ip_address_pre_req_cfg(False,'25.11.8.70/16','test_vrf')
+    time.sleep(20)
+
+    success = verify_ip_table_has_rule('test_vrf','25.11.8.70')
+    if success ==0:
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. No ip table rule for 25.11.8.70 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. ip table has a rule with ip 25.11.8.70 @@@@@@@@@@@@@@'
+    ip_service_pre_req_cfg('test_vrf',1)
+    time.sleep(20)
+
+
+    print '$$$$$$$$$$$$$$$$ TEST-3. configure ip service after ip address config $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '############## Make sure test_vrf vrf is available and it  has ip table rule #####'
+    print '#########################################################################################'
+
+#configured ip address first then configure ip service on that vrf. 
+    success = verify_ip_table_has_rule('test_vrf','25.11.8.70')
+    if success ==1:
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. ip table has a rule with ip 25.11.8.70 @@@@@@@@@@@@@@' 
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. No ip table rule for 25.11.8.70 @@@@@@@@@@@@@@'
+    ip_service_pre_req_cfg('test_vrf',0)
+    time.sleep(10)
+    ip_address_pre_req_cfg(True,'25.11.8.70/16','test_vrf')
+    time.sleep(20)
+
+   
+#Make sure no test_vrf is available in the Linux shell
+
+    if orig_run_command(['/sbin/ip', 'netns','exec', 'test_vrf','iptables','-t','nat','-L','PREROUTING'], resp) != 0:
+      print resp
+      if 'Cannot' in resp[0]:
+        print '@@@@@@@@@@@@@@ Unit test is PASSED.  vrf test_vrf and iptable rule is deleted from linux shell @@@@@@@@@@@@@@'
+      else:
+        print '@@@@@@@@@@@@@@ Unit test is FAILED. vrf test_vrf is still there in linux shell @@@@@@@@@@@@@@'
+
+
+    print '$$$$$$$$$$$$$$$$ TEST-4. configure ip address after enable ip service $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '############## Make sure test_vrf vrf is available and it  has ip table rule #####'
+    print '#########################################################################################'
+
+    ip_service_pre_req_cfg('test_vrf',1)
+    time.sleep(10)
+    ip_address_pre_req_cfg(False,'25.11.8.70/16','test_vrf')
+    time.sleep(20)
+
+#configure ip service first then configure ip address. 
+    success = verify_ip_table_has_rule('test_vrf','25.11.8.70')
+    if success ==1:
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Ip table rule is available for 25.11.8.70 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED.ip table rule is not available for 25.11.8.7 @@@@@@@@@@@@@@'
+
+    ip_address_pre_req_cfg(True,'25.11.8.70/16','test_vrf')
+    time.sleep(20)
+
+#Make sure no test_vrf is available in the Linux shell
+    if orig_run_command(['/sbin/ip', 'netns','exec', 'test_vrf','iptables','-t','nat','-L','PREROUTING'], resp) != 0:
+      print resp
+      if 'Cannot' in resp[0]:
+        print '@@@@@@@@@@@@@@ Unit test is PASSED. vrf test_vrf is deleted from linux shell @@@@@@@@@@@@@@'
+      else:
+        print '@@@@@@@@@@@@@@ Unit test is FAILED. vrf test_vrf is not deleted from linux shell @@@@@@@@@@@@@@'
+
+    print '$$$$$$$$$$$$$$$$ TEST-5. configure ip address in default vrf $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '############## Make sure no rule is added for 100.11.55.20 in default vrf  #####'
+    print '#########################################################################################'
+    default_ip_address_pre_req_cfg(False,'100.11.55.20/16')
+    success = verify_ip_table_has_rule('default','100.11.55.20')
+    if success ==1:
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Ip table rule is not available for 100.11.55.20 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED.ip table rule is  available for 100.11.55.20 @@@@@@@@@@@@@@'
+
+    default_ip_address_pre_req_cfg(True,'100.11.55.20/16')
+    time.sleep(10)
+
+    print '$$$$$$$$$$$$$$$$ TEST-6. configure ip address in multiple interfaces associated in red vrf  $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '############## Make sure rule is added for 1.1.1.1/2.1.1.1/3.1.1.1  in red vrf  #####'
+    print '#########################################################################################'
+
+    ip_address_multiple_interface_pre_req_cfg(False,'100.1.1.1/16','red')
+    time.sleep(20)
+      
+    success = verify_ip_table_has_rule('red','1.1.1.1')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are avaiable for red VRF 1.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for red VRF 1.1.1.1 @@@@@@@@@@@@@@'
+
+    time.sleep(20)
+
+    success = verify_ip_table_has_rule('red','2.1.1.1')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are avaiable for red VRF 2.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for red VRF 2.1.1.1 @@@@@@@@@@@@@@'
+
+    time.sleep(20)
+
+    success = verify_ip_table_has_rule('red','3.1.1.1')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are avaiable for red VRF 3.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for red VRF 3.1.1.1 @@@@@@@@@@@@@@'
+
+    success = verify_ip6_table_has_rule('red','fe80::/10')
+    if success ==1 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Ip6table rules are avaiable for red VRF fe80::/10 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are not avaiable for red VRF fe80::/10 @@@@@@@@@@@@@@'
+
+    print '$$$$$$$$$$$$$$$$ TEST-7. Remove ip address in multiple interfaces associated in red vrf  $$$$$$$$$$$$$$$'
+    print '#########################################################################################'
+    print '############## Make sure no rule is available  for 1.1.1.1/2.1.1.1/3.1.1.1  in red vrf  #####'
+    print '#########################################################################################'
+
+
+    ip_address_multiple_interface_remove_ip_cfg()
+
+    success = verify_ip_table_has_rule('red','1.1.1.1')
+    if success == 0 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are not avaiable for red VRF 1.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are avaiable for red VRF 1.1.1.1 @@@@@@@@@@@@@@'
+
+    time.sleep(10)
+    success = verify_ip_table_has_rule('red','2.1.1.1')
+    if success == 0 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are not avaiable for red VRF 2.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are avaiable for red VRF 2.1.1.1 @@@@@@@@@@@@@@'
+
+    time.sleep(10)
+
+    success = verify_ip_table_has_rule('red','3.1.1.1')
+    if success == 0 :
+      print '@@@@@@@@@@@@@@ Unit test is PASSED. Iptable rules are not avaiable for red VRF 3.1.1.1 @@@@@@@@@@@@@@'
+    else:
+      print '@@@@@@@@@@@@@@ Unit test is FAILED. Iptable rules are avaiable for red VRF 3.1.1.1 @@@@@@@@@@@@@@'
+    ip_address_multiple_interface_pre_req_cfg(True,'100.1.1.1/16','red')
+    time.sleep(10)
+
+if __name__ == '__main__':
+  test_ip_table_rule_for_non_default_vrf()

--- a/src/unit_test/scripts/vrf_ip_svcs_test.py
+++ b/src/unit_test/scripts/vrf_ip_svcs_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -14,7 +14,7 @@
 # permissions and limitations under the License.
 #
 
-from nas_incoming_svcs_ut import test_pre_req_cfg
+from nas_outgoing_svcs_ut import test_pre_req_cfg
 from nas_incoming_svcs_ut import run_test_incoming_svcs
 from nas_outgoing_svcs_ut import run_test_outgoing_svcs
 import time


### PR DESCRIPTION
* Update: publish FDB event with master index for remote MAC entry
* Update: disabling ipv6 config on sub interface in OS.
* Update: code changes to set admin status of all sub interfaces before handling the parent
        interface admin state, when parent interface needs to be shutdown.
* Update: avoid checking vlan Id in case of remote mac
* Bugfix: nas journal logs cleanup
* Feature: dhcp v4 and v6 snooping
* Feature: APIs to support loopback control in nas-linux
* Update: avoid the reserved IP address logs and fixed the module for journal log
* Bugfix: fixed the error logs for reserved IP address filter
* Update: management-vrf : install the ip/ip6 table rule based on source ip
* Update: If_type check is not required when the mgmt intf is getting associated with mgmt VRF
* Update: do not log an error when the LLA is configured from address handling thread.
* Update: added handling for icmpv6 protocol type
* Update: added the default VRF-id check for the interface util functions that are meant only for default VRF.
* Update: using id_generator_t to get the next unused vrf id.
* Update: update only the non-zero parent interface in the lower layer intf attribute while publishing the nbr event.
* Update: ignore route netlink events from OS if the route configurations are expected with CPS object from App
* Update: APIs to support loopback control in nas-linux
* Update: disable snooping in kernel for 1d bridges(Similar to 1Q bridges).
* Update: clearing per-vlan SAI stats
* Update: base mcast default journal logs
* Bugfix: management vrf - eth0 accepts junk packets if the destIP is not eth0's IP

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>