### PR TITLE
Bugfix: Added missing dependancy of python-ipaddress, python-enum34 for opx-nas-linux package 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-linux], [5.28.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-linux], [5.28.1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-nas-linux (5.28.1) unstable; urgency=medium
+
+  * Bugfix: Added missing dependancy of python-ipaddress, python-enum34 for opx-nas-linux package
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 06 Mar 2020 01:57:44 -0800
+
 opx-nas-linux (5.28.0) unstable; urgency=medium
 
   * Update: publish FDB event with master index for remote MAC entry

--- a/debian/control
+++ b/debian/control
@@ -22,5 +22,5 @@ Description: This package contains the Linux integration portion of the Network 
 
 Package: opx-nas-linux
 Architecture: any
-Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2)
+Depends: ${misc:Depends},opx-cps (>= 3.6.2),python-opx-cps (>= 3.6.2), python-ipaddress (>= 1.0.17-1), python-enum34 (>= 1.1.6-1)
 Description: This package contains the Linux integration portion of the Network abstractions service.


### PR DESCRIPTION
(open-switch/opx-tools#24)